### PR TITLE
Service abstractions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ venv.bak/
 .idea/
 .vscode/
 *.code-workspace
+.DS_Store
 
 temp/
 tmp/

--- a/banyan/api/__init__.py
+++ b/banyan/api/__init__.py
@@ -22,6 +22,8 @@ from banyan.api.netagent import NetagentAPI
 from banyan.api.policy import PolicyAPI
 from banyan.api.role import RoleAPI
 from banyan.api.service import ServiceAPI
+from banyan.api.service_web import ServiceWebAPI
+from banyan.api.service_infra import ServiceInfraAPI
 from banyan.api.shield import ShieldAPI
 from banyan.api.user import UserAPI
 from banyan.api.cloud_resource import CloudResourceAPI
@@ -96,7 +98,7 @@ class BanyanApiClient:
             requests_log = logging.getLogger('requests.packages.urllib3')
             requests_log.setLevel(logging.DEBUG)
             requests_log.propagate = True
-        self._http = self._create_session()
+        self._http = self._create_session()        
         self._services = ServiceAPI(self)
         self._policies = PolicyAPI(self)
         self._attach = AttachmentAPI(self)
@@ -108,6 +110,8 @@ class BanyanApiClient:
         self._events = EventV2API(self)
         self._audit = AuditAPI(self)
         self._cloud_resources = CloudResourceAPI(self)
+        self._services_web = ServiceWebAPI(self)
+        self._services_infra = ServiceInfraAPI(self)
 
     def __del__(self):
         if self._http:
@@ -319,6 +323,20 @@ class BanyanApiClient:
     @insecure_tls.setter
     def insecure_tls(self, value: bool) -> None:
         self._insecure_tls = value
+
+    @property
+    def services_web(self) -> ServiceWebAPI:
+        """
+        Returns an instance of the :py:class:`ServiceWebAPI` class, which can be used to manage Banyan hosted websites.
+        """
+        return self._services_web
+
+    @property
+    def services_infra(self) -> ServiceInfraAPI:
+        """
+        Returns an instance of the :py:class:`ServiceInfraAPI` class, which can be used to manage Banyan infra services.
+        """
+        return self._services_infra        
 
     @property
     def services(self) -> ServiceAPI:

--- a/banyan/api/audit.py
+++ b/banyan/api/audit.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from typing import List
 
-from banyan.api.base import ServiceBase, Resource
+from banyan.api.base import ApiBase, Resource
 from banyan.model import BanyanApiObject
 from banyan.model.audit import AuditEvent
 
 
-class AuditAPI(ServiceBase):
+class AuditAPI(ApiBase):
     class Meta:
         data_class = AuditEvent
         info_class = AuditEvent
@@ -27,7 +27,7 @@ class AuditAPI(ServiceBase):
 
     def list(self, before_dt: datetime = None, after_dt: datetime = None,
              event_type: str = None, action: str = None, admin_email: str = None) -> list:
-        params = ServiceBase.args_to_html_params([
+        params = ApiBase.args_to_html_params([
             (before_dt, 'end_time', int(before_dt.timestamp() * 1000000000) if before_dt else None),
             (after_dt, 'start_time', int(after_dt.timestamp() * 1000000000) if after_dt else None),
             (event_type, 'type', event_type),

--- a/banyan/api/base.py
+++ b/banyan/api/base.py
@@ -7,7 +7,7 @@ from banyan.model import InfoBase, BanyanApiObject, Resource, ResourceOrName
 InfoObjectOrName = Union[InfoBase, str]
 
 
-class ServiceBase(ABC):
+class ApiBase(ABC):
     class Meta:
         data_class = BanyanApiObject
         info_class = Resource

--- a/banyan/api/cloud_resource.py
+++ b/banyan/api/cloud_resource.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 import json
 
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model import BanyanApiObject
 from banyan.model.cloud_resource import CloudResource, CloudResourceInfo, CloudResourceAssociateInfo
 from banyan.model.service import ServiceInfoOrName
@@ -11,7 +11,7 @@ from banyan.api.service import ServiceAPI
 
 JsonListOrObj = Union[List, Dict]
 
-class CloudResourceAPI(ServiceBase):
+class CloudResourceAPI(ApiBase):
     class Meta:
         data_class = CloudResource
         info_class = CloudResourceInfo

--- a/banyan/api/device.py
+++ b/banyan/api/device.py
@@ -1,11 +1,11 @@
 from typing import List
 
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.core.exc import BanyanError
 from banyan.model.user_device import Device, TrustScore
 
 
-class DeviceAPI(ServiceBase):
+class DeviceAPI(ApiBase):
     """
     API service for dealing with end-user devices (laptops, tablets, phones, etc).
 

--- a/banyan/api/event_v2.py
+++ b/banyan/api/event_v2.py
@@ -4,12 +4,12 @@ from uuid import UUID
 
 from semver import deprecated
 
-from banyan.api.base import ServiceBase, Resource
+from banyan.api.base import ApiBase, Resource
 from banyan.model import BanyanApiObject
 from banyan.model.event_v2 import EventV2, EventOrID
 
 
-class EventV2API(ServiceBase):
+class EventV2API(ApiBase):
     class Meta:
         data_class = EventV2
         info_class = EventV2
@@ -104,7 +104,7 @@ class EventV2API(ServiceBase):
                      email_address: str = None, device_id: str = None, device_serial: str = None,
                      container_id: str = None, service_name: str = None, event_id: str = None,
                      limit: int = None) -> Dict[str, Any]:
-        return ServiceBase.args_to_html_params([
+        return ApiBase.args_to_html_params([
             (before_dt, 'before', lambda: int(before_dt.timestamp() * 1000)),
             (after_dt, 'after', lambda: int(after_dt.timestamp() * 1000)),
             (order, 'order', order),

--- a/banyan/api/netagent.py
+++ b/banyan/api/netagent.py
@@ -1,11 +1,11 @@
 from typing import List, Dict, Any
 
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model import Resource
 from banyan.model.netagent import Netagent
 
 
-class NetagentAPI(ServiceBase):
+class NetagentAPI(ApiBase):
     class Meta:
         data_class = Netagent
         info_class = Netagent

--- a/banyan/api/policy.py
+++ b/banyan/api/policy.py
@@ -1,10 +1,10 @@
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model.policy import PolicyInfo, Policy, PolicyInfoOrName, PolicyAttachInfo
 from banyan.model.service import ServiceInfoOrName
 from typing import List
 
 
-class PolicyAPI(ServiceBase):
+class PolicyAPI(ApiBase):
     class Meta:
         data_class = Policy
         info_class = PolicyInfo

--- a/banyan/api/role.py
+++ b/banyan/api/role.py
@@ -1,9 +1,9 @@
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model import BanyanApiObject
 from banyan.model.role import Role, RoleInfo, RoleInfoOrName
 
 
-class RoleAPI(ServiceBase):
+class RoleAPI(ApiBase):
     class Meta:
         data_class = Role
         info_class = RoleInfo

--- a/banyan/api/service.py
+++ b/banyan/api/service.py
@@ -1,8 +1,8 @@
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model.policy import PolicyInfo, PolicyInfoOrName, PolicyAttachInfo
 from banyan.model.service import ServiceInfo, Service, ServiceInfoOrName
 
-class ServiceAPI(ServiceBase):
+class ServiceAPI(ApiBase):
     class Meta:
         data_class = Service
         info_class = ServiceInfo

--- a/banyan/api/service_infra.py
+++ b/banyan/api/service_infra.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Union, Iterable, Any, Callable
+
 from banyan.api.base import ApiBase
 from banyan.model.policy import PolicyInfo, PolicyInfoOrName, PolicyAttachInfo
 from banyan.model.service import ServiceInfo, Service, ServiceInfoOrName
@@ -12,6 +14,17 @@ class ServiceInfraAPI(ApiBase):
         insert_uri = '/insert_registered_service'
         uri_param = 'ServiceID'
         obj_name = 'service'
+
+    def list(self, params: Dict[str, Any] = None) -> list:
+        list_func = self._client.api_request
+        response_json = list(list_func('GET', self.Meta.list_uri, params=params))
+        data: List[ServiceInfo] = self.Meta.info_class.Schema().load(response_json, many=True)
+        filtered_data = []
+        for svc in data:
+            if not svc.oidc_enabled:
+                filtered_data.append(svc)
+        self._build_cache(filtered_data)
+        return filtered_data
 
     def enable(self, service: ServiceInfoOrName) -> str:
         service = self.find(service)
@@ -34,9 +47,6 @@ class ServiceInfraAPI(ApiBase):
     def detach(self, service: ServiceInfoOrName, policy: PolicyInfoOrName) -> str:
         from banyan.api.policy import PolicyAPI
         return PolicyAPI(self._client).detach(policy, service)
-
-    def test(self, service: ServiceInfoOrName) -> None:
-        pass
 
     def attached_policy(self, service: ServiceInfoOrName) -> PolicyInfo:
         from banyan.model.policy import PolicyAttachInfo

--- a/banyan/api/service_infra.py
+++ b/banyan/api/service_infra.py
@@ -1,0 +1,45 @@
+from banyan.api.base import ApiBase
+from banyan.model.policy import PolicyInfo, PolicyInfoOrName, PolicyAttachInfo
+from banyan.model.service import ServiceInfo, Service, ServiceInfoOrName
+
+class ServiceInfraAPI(ApiBase):
+    class Meta:
+        data_class = Service
+        info_class = ServiceInfo
+        arg_type = ServiceInfoOrName
+        list_uri = '/registered_services'
+        delete_uri = '/delete_registered_service'
+        insert_uri = '/insert_registered_service'
+        uri_param = 'ServiceID'
+        obj_name = 'service'
+
+    def enable(self, service: ServiceInfoOrName) -> str:
+        service = self.find(service)
+        json_response = self._client.api_request('POST',
+                                                 '/enable_registered_service',
+                                                 params={'ServiceID': service.id})
+        return json_response['Message']
+
+    def disable(self, service: ServiceInfoOrName) -> str:
+        service = self.find(service)
+        json_response = self._client.api_request('POST',
+                                                 '/disable_registered_service',
+                                                 params={'ServiceID': service.id})
+        return json_response['Message']
+
+    def attach(self, service: ServiceInfoOrName, policy: PolicyInfoOrName, enforcing: bool) -> PolicyAttachInfo:
+        from banyan.api.policy import PolicyAPI
+        return PolicyAPI(self._client).attach(policy, service, enforcing)
+
+    def detach(self, service: ServiceInfoOrName, policy: PolicyInfoOrName) -> str:
+        from banyan.api.policy import PolicyAPI
+        return PolicyAPI(self._client).detach(policy, service)
+
+    def test(self, service: ServiceInfoOrName) -> None:
+        pass
+
+    def attached_policy(self, service: ServiceInfoOrName) -> PolicyInfo:
+        from banyan.model.policy import PolicyAttachInfo
+        service = self.find(service)
+        json_response = self._client.api_request('GET', f'/policy/attachment/service/{service.id}')
+        return PolicyAttachInfo.Schema().load(json_response[0]) if len(json_response) > 0 else None

--- a/banyan/api/service_web.py
+++ b/banyan/api/service_web.py
@@ -1,0 +1,45 @@
+from banyan.api.base import ApiBase
+from banyan.model.policy import PolicyInfo, PolicyInfoOrName, PolicyAttachInfo
+from banyan.model.service import ServiceInfo, Service, ServiceInfoOrName
+
+class ServiceWebAPI(ApiBase):
+    class Meta:
+        data_class = Service
+        info_class = ServiceInfo
+        arg_type = ServiceInfoOrName
+        list_uri = '/registered_services'
+        delete_uri = '/delete_registered_service'
+        insert_uri = '/insert_registered_service'
+        uri_param = 'ServiceID'
+        obj_name = 'service'
+
+    def enable(self, service: ServiceInfoOrName) -> str:
+        service = self.find(service)
+        json_response = self._client.api_request('POST',
+                                                 '/enable_registered_service',
+                                                 params={'ServiceID': service.id})
+        return json_response['Message']
+
+    def disable(self, service: ServiceInfoOrName) -> str:
+        service = self.find(service)
+        json_response = self._client.api_request('POST',
+                                                 '/disable_registered_service',
+                                                 params={'ServiceID': service.id})
+        return json_response['Message']
+
+    def attach(self, service: ServiceInfoOrName, policy: PolicyInfoOrName, enforcing: bool) -> PolicyAttachInfo:
+        from banyan.api.policy import PolicyAPI
+        return PolicyAPI(self._client).attach(policy, service, enforcing)
+
+    def detach(self, service: ServiceInfoOrName, policy: PolicyInfoOrName) -> str:
+        from banyan.api.policy import PolicyAPI
+        return PolicyAPI(self._client).detach(policy, service)
+
+    def test(self, service: ServiceInfoOrName) -> None:
+        pass
+
+    def attached_policy(self, service: ServiceInfoOrName) -> PolicyInfo:
+        from banyan.model.policy import PolicyAttachInfo
+        service = self.find(service)
+        json_response = self._client.api_request('GET', f'/policy/attachment/service/{service.id}')
+        return PolicyAttachInfo.Schema().load(json_response[0]) if len(json_response) > 0 else None

--- a/banyan/api/service_web.py
+++ b/banyan/api/service_web.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Union, Iterable, Any, Callable
+
 from banyan.api.base import ApiBase
 from banyan.model.policy import PolicyInfo, PolicyInfoOrName, PolicyAttachInfo
 from banyan.model.service import ServiceInfo, Service, ServiceInfoOrName
@@ -12,6 +14,17 @@ class ServiceWebAPI(ApiBase):
         insert_uri = '/insert_registered_service'
         uri_param = 'ServiceID'
         obj_name = 'service'
+
+    def list(self, params: Dict[str, Any] = None) -> list:
+        list_func = self._client.api_request
+        response_json = list(list_func('GET', self.Meta.list_uri, params=params))
+        data: List[ServiceInfo] = self.Meta.info_class.Schema().load(response_json, many=True)        
+        filtered_data = []
+        for svc in data:
+            if svc.oidc_enabled:
+                filtered_data.append(svc)
+        self._build_cache(filtered_data)
+        return filtered_data
 
     def enable(self, service: ServiceInfoOrName) -> str:
         service = self.find(service)
@@ -34,9 +47,6 @@ class ServiceWebAPI(ApiBase):
     def detach(self, service: ServiceInfoOrName, policy: PolicyInfoOrName) -> str:
         from banyan.api.policy import PolicyAPI
         return PolicyAPI(self._client).detach(policy, service)
-
-    def test(self, service: ServiceInfoOrName) -> None:
-        pass
 
     def attached_policy(self, service: ServiceInfoOrName) -> PolicyInfo:
         from banyan.model.policy import PolicyAttachInfo

--- a/banyan/api/shield.py
+++ b/banyan/api/shield.py
@@ -1,11 +1,11 @@
 from datetime import timezone, datetime
 from typing import List, Dict, Any
 
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model.shield import Shield, ShieldConfig
 
 
-class ShieldAPI(ServiceBase):
+class ShieldAPI(ApiBase):
     class Meta:
         data_class = Shield
         info_class = Shield

--- a/banyan/api/user.py
+++ b/banyan/api/user.py
@@ -1,10 +1,10 @@
 from typing import List
 
-from banyan.api.base import ServiceBase
+from banyan.api.base import ApiBase
 from banyan.model.user_device import User, TrustScore
 
 
-class UserAPI(ServiceBase):
+class UserAPI(ApiBase):
     class Meta:
         data_class = User
         info_class = User

--- a/banyan/controllers/service.py
+++ b/banyan/controllers/service.py
@@ -14,7 +14,7 @@ class ServiceController(Controller):
         label = 'service'
         stacked_type = 'nested'
         stacked_on = 'base'
-        help = 'manage web and TCP services and workloads'
+        help = '(deprecated) manage web and TCP services and workloads'
 
     @property
     def _client(self) -> ServiceAPI:

--- a/banyan/controllers/service_infra.py
+++ b/banyan/controllers/service_infra.py
@@ -5,7 +5,7 @@ from cement import Controller, ex
 from banyan.api.service_infra import ServiceInfraAPI
 from banyan.controllers.base import Base
 from banyan.model.service import ServiceInfo, Service
-
+from banyan.model.service_infra import ServiceInfraSSH, ServiceInfraRDP, ServiceInfraK8S, ServiceInfraDatabase, ServiceInfraTCP
 
 class ServiceInfraController(Controller):
     class Meta:
@@ -48,7 +48,7 @@ class ServiceInfraController(Controller):
         self.app.render(service_json, handler='json', indent=2, sort_keys=True)
 
 
-    @ex(help='create a new custom infrastructure service from a JSON specification',
+    @ex(help='create a new infrastructure service from a JSON specification',
         arguments=[
             (['service_spec'],
              {
@@ -56,14 +56,14 @@ class ServiceInfraController(Controller):
                          'containing JSON prefixed by "@" (example: @service.json).'
              }),
         ])
-    def create_custom(self):
+    def create(self):
         spec = Base.get_json_input(self.app.pargs.service_spec)
         service: ServiceInfo = Service.Schema().load(spec)
         info = self._client.create(service)
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
 
 
-    @ex(help='update an existing custom infrastructure service from a JSON specification',
+    @ex(help='update an existing infrastructure service from a JSON specification',
         arguments=[
             (['service_spec'],
              {
@@ -71,7 +71,7 @@ class ServiceInfraController(Controller):
                          'containing JSON prefixed by "@" (example: @service.json).'
              }),
         ])
-    def update_custom(self):
+    def update(self):
         spec = Base.get_json_input(self.app.pargs.service_spec)
         service: ServiceInfo = Service.Schema().load(spec)
         info = self._client.update(service)
@@ -158,3 +158,76 @@ class ServiceInfraController(Controller):
         ])
     def detach_policy(self):
         self.app.print(self._client.detach(self.app.pargs.service_name, self.app.pargs.policy_name))
+
+
+    @ex(help='quick create a new SSH infrastructure service',
+        arguments=ServiceInfraSSH.arguments()
+        )
+    def quick_create_ssh(self):
+        svc = ServiceInfraSSH()
+        for attr in vars(svc):
+            argval = getattr(self.app.pargs, attr)
+            if argval is not None:
+                setattr(svc, attr, argval)
+        svc.initialize()
+        Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
+        info = self._client.create(svc.service_obj())
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+
+    @ex(help='quick create a new K8S infrastructure service',
+        arguments=ServiceInfraK8S.arguments()
+        )
+    def quick_create_k8s(self):
+        svc = ServiceInfraK8S()
+        for attr in vars(svc):
+            argval = getattr(self.app.pargs, attr)
+            if argval is not None:
+                setattr(svc, attr, argval)
+        svc.initialize()
+        Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
+        info = self._client.create(svc.service_obj())
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+
+    @ex(help='quick create a new RDP infrastructure service',
+        arguments=ServiceInfraRDP.arguments()
+        )
+    def quick_create_rdp(self):
+        svc = ServiceInfraRDP()
+        for attr in vars(svc):
+            argval = getattr(self.app.pargs, attr)
+            if argval is not None:
+                setattr(svc, attr, argval)
+        svc.initialize()
+        Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
+        info = self._client.create(svc.service_obj())
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+    @ex(help='quick create a new Database infrastructure service',
+        arguments=ServiceInfraDatabase.arguments()
+        )
+    def quick_create_db(self):
+        svc = ServiceInfraDatabase()
+        for attr in vars(svc):
+            argval = getattr(self.app.pargs, attr)
+            if argval is not None:
+                setattr(svc, attr, argval)
+        svc.initialize()
+        Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
+        info = self._client.create(svc.service_obj())
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+    @ex(help='quick create a new Generic TCP infrastructure service',
+        arguments=ServiceInfraTCP.arguments()
+        )
+    def quick_create_tcp(self):
+        svc = ServiceInfraTCP()
+        for attr in vars(svc):
+            argval = getattr(self.app.pargs, attr)
+            if argval is not None:
+                setattr(svc, attr, argval)
+        svc.initialize()
+        Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
+        info = self._client.create(svc.service_obj())
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)                 

--- a/banyan/controllers/service_infra.py
+++ b/banyan/controllers/service_infra.py
@@ -1,0 +1,157 @@
+from typing import List
+
+from cement import Controller, ex
+
+from banyan.api.service_infra import ServiceInfraAPI
+from banyan.controllers.base import Base
+from banyan.model.service import ServiceInfo, Service
+
+
+class ServiceInfraController(Controller):
+    class Meta:
+        label = 'service_infra'
+        stacked_type = 'nested'
+        stacked_on = 'base'
+        help = 'manage infrastructure services'
+
+    @property
+    def _client(self) -> ServiceInfraAPI:
+        return self.app.client.services_infra
+
+    @ex(help='list registered services')
+    def list(self):
+        services: List[ServiceInfo] = self._client.list()
+        results = list()
+        headers = ['Name', 'ID', 'Type', 'Enabled', 'Created', 'Last Updated']
+        for service in services:
+            app_type = service.service.metadata.tags.service_app_type
+            new_row = [service.service_name, service.service_id, app_type, service.enabled,
+                       service.created_at.strftime(Base.TABLE_DATE_FORMAT),
+                       service.last_updated_at.strftime(Base.TABLE_DATE_FORMAT)]
+            results.append(new_row)
+        results.sort(key=lambda x: x[0])
+        self.app.render(results, handler='tabulate', headers=headers, tablefmt='simple')
+
+    @ex(help='show the definition of a registered service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to display.'
+             }),
+        ])
+    def get(self):
+        info: ServiceInfo = self._client[self.app.pargs.service_name]
+        service_json = Service.Schema().dump(info.service)
+        # colorized_json = highlight(service_json, lexers.JsonLexer(), formatters.Terminal256Formatter(style="default"))
+        self.app.render(service_json, handler='json', indent=2, sort_keys=True)
+
+    @ex(help='create a new service from a JSON specification',
+        arguments=[
+            (['service_spec'],
+             {
+                 'help': 'JSON blob describing the new service to be created, or a filename '
+                         'containing JSON prefixed by "@" (example: @service.json).'
+             }),
+        ])
+    def create(self):
+        spec = Base.get_json_input(self.app.pargs.service_spec)
+        service: ServiceInfo = Service.Schema().load(spec)
+        info = self._client.create(service)
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+    @ex(help='update an existing service from a JSON specification',
+        arguments=[
+            (['service_spec'],
+             {
+                 'help': 'JSON blob describing the service to be updated, or a filename '
+                         'containing JSON prefixed by "@" (example: @service.json).'
+             }),
+        ])
+    def update(self):
+        spec = Base.get_json_input(self.app.pargs.service_spec)
+        service: ServiceInfo = Service.Schema().load(spec)
+        info = self._client.update(service)
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+    @ex(help='delete a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to delete.'
+             }),
+        ])
+    def delete(self):
+        service: ServiceInfo = self._client[self.app.pargs.service_name]
+        self.app.print(self._client.delete(service))
+
+    @ex(help='enable a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to enable.'
+             }),
+        ])
+    def enable(self):
+        service: ServiceInfo = self._client[self.app.pargs.service_name]
+        self.app.print(self._client.enable(service))
+
+    @ex(help='disable a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to disable.'
+             }),
+        ])
+    def disable(self):
+        service: ServiceInfo = self._client[self.app.pargs.service_name]
+        self.app.print(self._client.disable(service))
+
+    @ex(help='attach a policy to a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to attach a policy to.',
+             }),
+            (['policy_name'],
+             {
+                 'metavar': 'policy_name_or_id',
+                 'help': 'Name or ID of the policy to attach to the service.',
+             }),
+            (['--permissive'],
+             {
+                 'action': 'store_false',
+                 'dest': 'enforcing',
+                 'help': 'Set the policy to permissive mode (allow all traffic and log any unauthorized access).',
+             }),
+            (['--enforcing'], {
+                'action': 'store_true',
+                'dest': 'enforcing',
+                'default': True,
+                'help': 'Set the policy to enforcing mode (deny unauthorized access).',
+            }),
+        ])
+    def attach_policy(self):
+        result = self._client.attach(self.app.pargs.service_name, self.app.pargs.policy_name, self.app.pargs.enforcing)
+        mode = 'ENFORCING' if result.enabled else 'PERMISSIVE'
+        self.app.print(f'Policy {result.policy_id} attached to service {result.service_id} in {mode} mode.')
+
+    @ex(help='detach the active policy from a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to attach a policy to.',
+             }),
+            (['policy_name'],
+             {
+                 'metavar': 'policy_name_or_id',
+                 'help': 'Name or ID of the policy to attach to the service.',
+             }),
+        ])
+    def detach_policy(self):
+        self.app.print(self._client.detach(self.app.pargs.service_name, self.app.pargs.policy_name))

--- a/banyan/controllers/service_infra.py
+++ b/banyan/controllers/service_infra.py
@@ -169,7 +169,6 @@ class ServiceInfraController(Controller):
             argval = getattr(self.app.pargs, attr)
             if argval is not None:
                 setattr(svc, attr, argval)
-        svc.initialize()
         Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
         info = self._client.create(svc.service_obj())
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
@@ -184,7 +183,6 @@ class ServiceInfraController(Controller):
             argval = getattr(self.app.pargs, attr)
             if argval is not None:
                 setattr(svc, attr, argval)
-        svc.initialize()
         Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
         info = self._client.create(svc.service_obj())
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
@@ -199,7 +197,6 @@ class ServiceInfraController(Controller):
             argval = getattr(self.app.pargs, attr)
             if argval is not None:
                 setattr(svc, attr, argval)
-        svc.initialize()
         Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
         info = self._client.create(svc.service_obj())
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
@@ -213,7 +210,6 @@ class ServiceInfraController(Controller):
             argval = getattr(self.app.pargs, attr)
             if argval is not None:
                 setattr(svc, attr, argval)
-        svc.initialize()
         Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
         info = self._client.create(svc.service_obj())
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
@@ -227,7 +223,6 @@ class ServiceInfraController(Controller):
             argval = getattr(self.app.pargs, attr)
             if argval is not None:
                 setattr(svc, attr, argval)
-        svc.initialize()
         Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
         info = self._client.create(svc.service_obj())
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)

--- a/banyan/controllers/service_infra.py
+++ b/banyan/controllers/service_infra.py
@@ -230,4 +230,5 @@ class ServiceInfraController(Controller):
         svc.initialize()
         Base.wait_for_input(True, 'Creating an infrastructure service: ' + str(svc))
         info = self._client.create(svc.service_obj())
-        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)                 
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+        

--- a/banyan/controllers/service_infra.py
+++ b/banyan/controllers/service_infra.py
@@ -18,7 +18,7 @@ class ServiceInfraController(Controller):
     def _client(self) -> ServiceInfraAPI:
         return self.app.client.services_infra
 
-    @ex(help='list registered services')
+    @ex(help='list infrastructure services')
     def list(self):
         services: List[ServiceInfo] = self._client.list()
         results = list()
@@ -32,7 +32,8 @@ class ServiceInfraController(Controller):
         results.sort(key=lambda x: x[0])
         self.app.render(results, handler='tabulate', headers=headers, tablefmt='simple')
 
-    @ex(help='show the definition of a registered service',
+
+    @ex(help='show the definition of a infrastructure service',
         arguments=[
             (['service_name'],
              {
@@ -46,7 +47,8 @@ class ServiceInfraController(Controller):
         # colorized_json = highlight(service_json, lexers.JsonLexer(), formatters.Terminal256Formatter(style="default"))
         self.app.render(service_json, handler='json', indent=2, sort_keys=True)
 
-    @ex(help='create a new service from a JSON specification',
+
+    @ex(help='create a new custom infrastructure service from a JSON specification',
         arguments=[
             (['service_spec'],
              {
@@ -54,13 +56,14 @@ class ServiceInfraController(Controller):
                          'containing JSON prefixed by "@" (example: @service.json).'
              }),
         ])
-    def create(self):
+    def create_custom(self):
         spec = Base.get_json_input(self.app.pargs.service_spec)
         service: ServiceInfo = Service.Schema().load(spec)
         info = self._client.create(service)
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
 
-    @ex(help='update an existing service from a JSON specification',
+
+    @ex(help='update an existing custom infrastructure service from a JSON specification',
         arguments=[
             (['service_spec'],
              {
@@ -68,13 +71,13 @@ class ServiceInfraController(Controller):
                          'containing JSON prefixed by "@" (example: @service.json).'
              }),
         ])
-    def update(self):
+    def update_custom(self):
         spec = Base.get_json_input(self.app.pargs.service_spec)
         service: ServiceInfo = Service.Schema().load(spec)
         info = self._client.update(service)
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
 
-    @ex(help='delete a service',
+    @ex(help='delete an infrastructure service',
         arguments=[
             (['service_name'],
              {
@@ -86,7 +89,7 @@ class ServiceInfraController(Controller):
         service: ServiceInfo = self._client[self.app.pargs.service_name]
         self.app.print(self._client.delete(service))
 
-    @ex(help='enable a service',
+    @ex(help='enable an infrastructure service',
         arguments=[
             (['service_name'],
              {
@@ -98,7 +101,7 @@ class ServiceInfraController(Controller):
         service: ServiceInfo = self._client[self.app.pargs.service_name]
         self.app.print(self._client.enable(service))
 
-    @ex(help='disable a service',
+    @ex(help='disable an infrastructure service',
         arguments=[
             (['service_name'],
              {
@@ -110,7 +113,7 @@ class ServiceInfraController(Controller):
         service: ServiceInfo = self._client[self.app.pargs.service_name]
         self.app.print(self._client.disable(service))
 
-    @ex(help='attach a policy to a service',
+    @ex(help='attach a policy to an infrastructure service',
         arguments=[
             (['service_name'],
              {
@@ -140,7 +143,7 @@ class ServiceInfraController(Controller):
         mode = 'ENFORCING' if result.enabled else 'PERMISSIVE'
         self.app.print(f'Policy {result.policy_id} attached to service {result.service_id} in {mode} mode.')
 
-    @ex(help='detach the active policy from a service',
+    @ex(help='detach the active policy from an infrastructure service',
         arguments=[
             (['service_name'],
              {

--- a/banyan/controllers/service_web.py
+++ b/banyan/controllers/service_web.py
@@ -1,0 +1,230 @@
+from typing import List
+
+from cement import Controller, ex
+
+from banyan.api.service_web import ServiceWebAPI
+from banyan.controllers.base import Base
+from banyan.model.service import ServiceInfo, Service
+
+
+class ServiceWebController(Controller):
+    class Meta:
+        label = 'service_web'
+        stacked_type = 'nested'
+        stacked_on = 'base'
+        help = 'manage hosted websites'
+
+    @property
+    def _client(self) -> ServiceWebAPI:
+        return self.app.client.services_web
+
+    @ex(help='list registered services')
+    def list(self):
+        services: List[ServiceInfo] = self._client.list()
+        results = list()
+        headers = ['Name', 'ID', 'Type', 'Enabled', 'Created', 'Last Updated']
+        for service in services:
+            app_type = service.service.metadata.tags.service_app_type
+            new_row = [service.service_name, service.service_id, app_type, service.enabled,
+                       service.created_at.strftime(Base.TABLE_DATE_FORMAT),
+                       service.last_updated_at.strftime(Base.TABLE_DATE_FORMAT)]
+            results.append(new_row)
+        results.sort(key=lambda x: x[0])
+        self.app.render(results, handler='tabulate', headers=headers, tablefmt='simple')
+
+    @ex(help='show the definition of a registered service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to display.'
+             }),
+        ])
+    def get(self):
+        info: ServiceInfo = self._client[self.app.pargs.service_name]
+        service_json = Service.Schema().dump(info.service)
+        # colorized_json = highlight(service_json, lexers.JsonLexer(), formatters.Terminal256Formatter(style="default"))
+        self.app.render(service_json, handler='json', indent=2, sort_keys=True)
+
+    @ex(help='create a new service from a JSON specification',
+        arguments=[
+            (['service_spec'],
+             {
+                 'help': 'JSON blob describing the new service to be created, or a filename '
+                         'containing JSON prefixed by "@" (example: @service.json).'
+             }),
+        ])
+    def create(self):
+        spec = Base.get_json_input(self.app.pargs.service_spec)
+        service: ServiceInfo = Service.Schema().load(spec)
+        info = self._client.create(service)
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+    @ex(help='update an existing service from a JSON specification',
+        arguments=[
+            (['service_spec'],
+             {
+                 'help': 'JSON blob describing the service to be updated, or a filename '
+                         'containing JSON prefixed by "@" (example: @service.json).'
+             }),
+        ])
+    def update(self):
+        spec = Base.get_json_input(self.app.pargs.service_spec)
+        service: ServiceInfo = Service.Schema().load(spec)
+        info = self._client.update(service)
+        self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
+
+    @ex(help='delete a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to delete.'
+             }),
+        ])
+    def delete(self):
+        service: ServiceInfo = self._client[self.app.pargs.service_name]
+        self.app.print(self._client.delete(service))
+
+    @ex(help='enable a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to enable.'
+             }),
+        ])
+    def enable(self):
+        service: ServiceInfo = self._client[self.app.pargs.service_name]
+        self.app.print(self._client.enable(service))
+
+    @ex(help='disable a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to disable.'
+             }),
+        ])
+    def disable(self):
+        service: ServiceInfo = self._client[self.app.pargs.service_name]
+        self.app.print(self._client.disable(service))
+
+    @ex(help='attach a policy to a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to attach a policy to.',
+             }),
+            (['policy_name'],
+             {
+                 'metavar': 'policy_name_or_id',
+                 'help': 'Name or ID of the policy to attach to the service.',
+             }),
+            (['--permissive'],
+             {
+                 'action': 'store_false',
+                 'dest': 'enforcing',
+                 'help': 'Set the policy to permissive mode (allow all traffic and log any unauthorized access).',
+             }),
+            (['--enforcing'], {
+                'action': 'store_true',
+                'dest': 'enforcing',
+                'default': True,
+                'help': 'Set the policy to enforcing mode (deny unauthorized access).',
+            }),
+        ])
+    def attach_policy(self):
+        result = self._client.attach(self.app.pargs.service_name, self.app.pargs.policy_name, self.app.pargs.enforcing)
+        mode = 'ENFORCING' if result.enabled else 'PERMISSIVE'
+        self.app.print(f'Policy {result.policy_id} attached to service {result.service_id} in {mode} mode.')
+
+    @ex(help='detach the active policy from a service',
+        arguments=[
+            (['service_name'],
+             {
+                 'metavar': 'service_name_or_id',
+                 'help': 'Name or ID of the service to attach a policy to.',
+             }),
+            (['policy_name'],
+             {
+                 'metavar': 'policy_name_or_id',
+                 'help': 'Name or ID of the policy to attach to the service.',
+             }),
+        ])
+    def detach_policy(self):
+        self.app.print(self._client.detach(self.app.pargs.service_name, self.app.pargs.policy_name))
+
+
+    @ex(help='create an Okta Bookmark Application from a web service',
+        arguments=[
+            (['service_name'],
+            {
+                'help': 'name of service to add to Okta.'
+            }),
+            (['group_name'],
+            {
+                'help': 'Okta group to assign application access.'
+            }),            
+        ])
+    def bookmark_okta(self):
+        try:
+            from banyan.ext.idp.okta import OktaApplicationController
+        except Exception as ex:
+            raise NotImplementedError("Okta SDK not configured correctly > %s" % ex.args[0])
+
+        self._client.list()
+        service_info: ServiceInfo = self._client[self.app.pargs.service_name]
+        if not service_info.service.spec.http_settings.oidc_settings.enabled:
+            raise RuntimeError('Service needs to be of type WEB')
+
+        Base.wait_for_input(True, 'Get service to add to Okta:')
+        svc = service_info.service
+        service_json = Service.Schema().dump(svc)
+        self.app.render(service_json, handler='json', indent=2, sort_keys=True)
+
+        Base.wait_for_input(True, 'Adding to Okta and assigning group.')
+        okta = OktaApplicationController()
+        okta_app = okta.create_bookmark(svc.name, svc.spec.http_settings.oidc_settings.service_domain_name)
+        print(okta_app)
+        okta_assignment = okta.assign(okta_app.id, self.app.pargs.group_name)
+        print(okta_assignment)
+
+        print('\n--> Bookmark to Okta successful.')
+
+
+    @ex(help='create an Azure AD Linked Sign-on from a web service',
+    arguments=[
+        (['service_name'],
+        {
+            'help': 'name of service to add to Azure AD.'
+        }),
+        (['group_name'],
+        {
+            'help': 'Azure AD group to assign application access.'
+        }),            
+    ])
+    def bookmark_aad(self):
+        try:
+            from banyan.ext.idp.azure_ad import AzureADApplicationController
+        except Exception as ex:
+            raise NotImplementedError("Azure AD Microsoft Graph SDK not configured correctly > %s" % ex.args[0]) 
+
+        self._client.list()
+        service_info: ServiceInfo = self._client[self.app.pargs.service_name]
+        if not service_info.service.spec.http_settings.oidc_settings.enabled:
+            raise RuntimeError('Service needs to be of type WEB')
+
+        Base.wait_for_input(True, 'Get service to add to AzureAD:')
+        svc = service_info.service
+        service_json = Service.Schema().dump(svc)
+        self.app.render(service_json, handler='json', indent=2, sort_keys=True)
+
+        Base.wait_for_input(True, 'Adding to Azure AD and assigning group.')
+        aad = AzureADApplicationController()
+        aad_app = aad.create_bookmark(svc.name, svc.spec.http_settings.oidc_settings.service_domain_name)
+        print(aad_app)
+
+        print('\n--> Bookmark to Azure AD successful.')
+        

--- a/banyan/controllers/service_web.py
+++ b/banyan/controllers/service_web.py
@@ -12,13 +12,14 @@ class ServiceWebController(Controller):
         label = 'service_web'
         stacked_type = 'nested'
         stacked_on = 'base'
-        help = 'manage hosted websites'
+        help = 'manage hosted website services'
 
     @property
     def _client(self) -> ServiceWebAPI:
         return self.app.client.services_web
 
-    @ex(help='list registered services')
+
+    @ex(help='list hosted website services')
     def list(self):
         services: List[ServiceInfo] = self._client.list()
         results = list()
@@ -32,7 +33,8 @@ class ServiceWebController(Controller):
         results.sort(key=lambda x: x[0])
         self.app.render(results, handler='tabulate', headers=headers, tablefmt='simple')
 
-    @ex(help='show the definition of a registered service',
+
+    @ex(help='show the definition of a hosted website service',
         arguments=[
             (['service_name'],
              {
@@ -46,7 +48,8 @@ class ServiceWebController(Controller):
         # colorized_json = highlight(service_json, lexers.JsonLexer(), formatters.Terminal256Formatter(style="default"))
         self.app.render(service_json, handler='json', indent=2, sort_keys=True)
 
-    @ex(help='create a new service from a JSON specification',
+
+    @ex(help='create a new standard hosted website service',
         arguments=[
             (['service_spec'],
              {
@@ -54,13 +57,24 @@ class ServiceWebController(Controller):
                          'containing JSON prefixed by "@" (example: @service.json).'
              }),
         ])
-    def create(self):
+    def create_standard(self):
+        pass
+
+    @ex(help='create a new custom hosted website service from a JSON specification',
+        arguments=[
+            (['service_spec'],
+             {
+                 'help': 'JSON blob describing the new service to be created, or a filename '
+                         'containing JSON prefixed by "@" (example: @service.json).'
+             }),
+        ])
+    def create_custom(self):
         spec = Base.get_json_input(self.app.pargs.service_spec)
         service: ServiceInfo = Service.Schema().load(spec)
         info = self._client.create(service)
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
 
-    @ex(help='update an existing service from a JSON specification',
+    @ex(help='update an existing custom hosted website service from a JSON specification',
         arguments=[
             (['service_spec'],
              {
@@ -68,13 +82,13 @@ class ServiceWebController(Controller):
                          'containing JSON prefixed by "@" (example: @service.json).'
              }),
         ])
-    def update(self):
+    def update_custom(self):
         spec = Base.get_json_input(self.app.pargs.service_spec)
         service: ServiceInfo = Service.Schema().load(spec)
         info = self._client.update(service)
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
 
-    @ex(help='delete a service',
+    @ex(help='delete a hosted website service',
         arguments=[
             (['service_name'],
              {
@@ -86,7 +100,7 @@ class ServiceWebController(Controller):
         service: ServiceInfo = self._client[self.app.pargs.service_name]
         self.app.print(self._client.delete(service))
 
-    @ex(help='enable a service',
+    @ex(help='enable a hosted website service',
         arguments=[
             (['service_name'],
              {
@@ -98,7 +112,7 @@ class ServiceWebController(Controller):
         service: ServiceInfo = self._client[self.app.pargs.service_name]
         self.app.print(self._client.enable(service))
 
-    @ex(help='disable a service',
+    @ex(help='disable a hosted website service',
         arguments=[
             (['service_name'],
              {
@@ -110,7 +124,7 @@ class ServiceWebController(Controller):
         service: ServiceInfo = self._client[self.app.pargs.service_name]
         self.app.print(self._client.disable(service))
 
-    @ex(help='attach a policy to a service',
+    @ex(help='attach a policy to a hosted website service',
         arguments=[
             (['service_name'],
              {
@@ -140,7 +154,7 @@ class ServiceWebController(Controller):
         mode = 'ENFORCING' if result.enabled else 'PERMISSIVE'
         self.app.print(f'Policy {result.policy_id} attached to service {result.service_id} in {mode} mode.')
 
-    @ex(help='detach the active policy from a service',
+    @ex(help='detach the active policy from a hosted website service',
         arguments=[
             (['service_name'],
              {
@@ -157,7 +171,7 @@ class ServiceWebController(Controller):
         self.app.print(self._client.detach(self.app.pargs.service_name, self.app.pargs.policy_name))
 
 
-    @ex(help='create an Okta Bookmark Application from a web service',
+    @ex(help='create an Okta Bookmark Application from a hosted website service',
         arguments=[
             (['service_name'],
             {
@@ -194,7 +208,7 @@ class ServiceWebController(Controller):
         print('\n--> Bookmark to Okta successful.')
 
 
-    @ex(help='create an Azure AD Linked Sign-on from a web service',
+    @ex(help='create an Azure AD Linked Sign-on from a hosted website service',
     arguments=[
         (['service_name'],
         {

--- a/banyan/controllers/service_web.py
+++ b/banyan/controllers/service_web.py
@@ -169,7 +169,6 @@ class ServiceWebController(Controller):
             argval = getattr(self.app.pargs, attr)
             if argval is not None:
                 setattr(svc_web, attr, argval)
-        svc_web.initialize()
         Base.wait_for_input(True, 'Creating a hosted website service: ' + str(svc_web))
         info = self._client.create(svc_web.service_obj())
         self.app.render(ServiceInfo.Schema().dump(info), handler='json', indent=2, sort_keys=True)
@@ -184,13 +183,13 @@ class ServiceWebController(Controller):
             (['group_name'],
             {
                 'help': 'Okta group to assign application access.'
-            }),            
+            }),         
         ])
     def bookmark_okta(self):
         try:
             from banyan.ext.idp.okta import OktaApplicationController
-        except Exception as ex:
-            raise NotImplementedError("Okta SDK not configured correctly > %s" % ex.args[0])
+        except Exception as exc:
+            raise NotImplementedError("Okta SDK not configured correctly > %s" % exc.args[0])
 
         self._client.list()
         service_info: ServiceInfo = self._client[self.app.pargs.service_name]
@@ -226,8 +225,8 @@ class ServiceWebController(Controller):
     def bookmark_aad(self):
         try:
             from banyan.ext.idp.azure_ad import AzureADApplicationController
-        except Exception as ex:
-            raise NotImplementedError("Azure AD Microsoft Graph SDK not configured correctly > %s" % ex.args[0]) 
+        except Exception as exc:
+            raise NotImplementedError("Azure AD Microsoft Graph SDK not configured correctly > %s" % exc.args[0]) 
 
         self._client.list()
         service_info: ServiceInfo = self._client[self.app.pargs.service_name]

--- a/banyan/main.py
+++ b/banyan/main.py
@@ -14,6 +14,8 @@ from banyan.controllers.netagent import NetagentController
 from banyan.controllers.policy import PolicyController
 from banyan.controllers.role import RoleController
 from banyan.controllers.service import ServiceController
+from banyan.controllers.service_web import ServiceWebController
+from banyan.controllers.service_infra import ServiceInfraController
 from banyan.controllers.shield import ShieldController
 from banyan.controllers.user import UserController
 from banyan.controllers.cloud_resource import CloudResourceController
@@ -81,6 +83,8 @@ class MyApp(App):
         handlers = [
             Base,
             CloudResourceController,
+            ServiceInfraController,
+            ServiceWebController,
             ServiceController,
             RoleController,
             PolicyController,

--- a/banyan/model/service.py
+++ b/banyan/model/service.py
@@ -32,23 +32,23 @@ class Tags:
         unknown = EXCLUDE
 
     template: str = field(metadata={'validate': validate.OneOf(ServiceTemplate.choices() + ["USER_WEB", "USER_TCP"])})
+    service_app_type: str = field(metadata={'validate': validate.OneOf(ServiceAppType.choices())})
     user_facing: bool = field(metadata={'marshmallow_field': fields.String()})
     protocol: str
     domain: str
     port: int = field(metadata={'marshmallow_field': fields.String(), 'allow_none': True})
-    service_app_type: str = field(metadata={'validate': validate.OneOf(ServiceAppType.choices())})
-    enforcement_mode: Optional[str]
-    allow_user_override: Optional[bool]
-    banyanproxy_mode: Optional[str]
-    app_listen_port: Optional[str]
-    ssh_service_type: Optional[str]
-    ssh_chain_mode: Optional[bool] 
-    ssh_host_directive: Optional[str]
-    write_ssh_config: Optional[bool]
-    kube_cluster_name: Optional[str]
-    kube_ca_key: Optional[str]
-    description_link: Optional[str]
-    include_domains: Optional[List[str]]
+    enforcement_mode: Optional[str] = ''
+    allow_user_override: Optional[bool] = field(default=False)
+    banyanproxy_mode: Optional[str] = ''
+    app_listen_port: Optional[str] = ''
+    ssh_service_type: Optional[str] = ''
+    ssh_chain_mode: Optional[bool] = field(default=False)
+    ssh_host_directive: Optional[str] = ''
+    write_ssh_config: Optional[bool] = field(default=False)
+    kube_cluster_name: Optional[str] = ''
+    kube_ca_key: Optional[str] = ''
+    description_link: Optional[str] = ''
+    include_domains: Optional[List[str]] = field(default_factory=list)
     icon: str = field(default="")
     Schema: ClassVar[Schema] = Schema
 
@@ -216,12 +216,12 @@ class HttpSettings:
 
     enabled: bool
     oidc_settings: Optional[OIDCSettings]
-    exempted_paths: Optional[ExemptedPaths]
-    http_health_check: Optional[HTTPHealthCheck] # deprecated
-    http_redirect: Optional[HTTPRedirect] # deprecated
-    headers: Optional[Dict[str, str]]
-    custom_trust_cookie: Optional[CustomTrustCookie]
-    token_loc: Optional[TokenLocation]
+    exempted_paths: Optional[ExemptedPaths] = field(default_factory=dict)
+    #http_health_check: Optional[HTTPHealthCheck] # deprecated
+    #http_redirect: Optional[HTTPRedirect] # deprecated
+    headers: Optional[Dict[str, str]] = field(default_factory=dict)
+    custom_trust_cookie: Optional[CustomTrustCookie] = field(default_factory=dict)
+    token_loc: Optional[TokenLocation] = field(default_factory=dict)
 
 
 @dataclass
@@ -249,7 +249,7 @@ class BackendTarget:
         unknown = EXCLUDE
 
     name: Optional[str]
-    name_delimiter: Optional[str]
+    name_delimiter: Optional[str] = ''
     port: int = field(default=443, metadata={'marshmallow_field': fields.String(), 'allow_none': True})
     tls: Optional[bool] = False
     tls_insecure: Optional[bool] = False
@@ -275,6 +275,7 @@ class Backend:
     allow_patterns: Optional[List[AllowPattern]] = field(default_factory=list)
     whitelist: Optional[List[str]] = field(default_factory=list) # deprecated
     http_connect: Optional[bool] = False
+    connector_name: Optional[str] = ''
 
 
 @dataclass

--- a/banyan/model/service.py
+++ b/banyan/model/service.py
@@ -15,16 +15,25 @@ class ServiceTemplate(BanyanEnum):
     WORKLOAD = "TCP_WORKLOAD"
     CUSTOM = "CUSTOM"
 
-
 class ServiceAppType(BanyanEnum):
     WEB = "WEB"
     SSH = "SSH"
-    TCP = "TCP"
     RDP = "RDP"
     K8S = "K8S"
-    GENERIC = "GENERIC"
-    CUSTOM = "CUSTOM"
+    DATABASE = "DATABASE"
+    TCP = "TCP"
 
+class ServiceClientCertificateType(BanyanEnum): 
+    TRUSTCERT = "TRUSTCERT"
+    SSHCERT = "SSHCERT"
+    BOTH = "BOTH"
+
+class ServiceClientProxyMode(BanyanEnum):
+    CHAIN = "CHAIN"
+    BASTION = "BASTION",
+    CONNECT = "CONNECT" # unused
+    TCP = "TCP"
+    RDPGATEWAY = "RDPGATEWAY"
 
 @dataclass
 class Tags:
@@ -37,18 +46,24 @@ class Tags:
     protocol: str
     domain: str
     port: int = field(metadata={'marshmallow_field': fields.String(), 'allow_none': True})
-    enforcement_mode: Optional[str] = ''
+
+    app_listen_port: Optional[int] = field(default='', metadata={'marshmallow_field': fields.String(), 'allow_none': True})
+    ssh_service_type: Optional[str] = field(default='', metadata={'validate': validate.OneOf(ServiceClientCertificateType.choices())})
+    banyanproxy_mode: Optional[str] = field(default='', metadata={'validate': validate.OneOf(ServiceClientProxyMode.choices())})
+
+    description_link: Optional[str] = field(default='')
+    enforcement_mode: Optional[str] = field(default='')
     allow_user_override: Optional[bool] = field(default=False)
-    banyanproxy_mode: Optional[str] = ''
-    app_listen_port: Optional[str] = ''
-    ssh_service_type: Optional[str] = ''
+
     ssh_chain_mode: Optional[bool] = field(default=False)
-    ssh_host_directive: Optional[str] = ''
+    ssh_host_directive: Optional[str] = field(default='')
     write_ssh_config: Optional[bool] = field(default=False)
-    kube_cluster_name: Optional[str] = ''
-    kube_ca_key: Optional[str] = ''
-    description_link: Optional[str] = ''
+
+    kube_cluster_name: Optional[str] = field(default='')
+    kube_ca_key: Optional[str] = field(default='')
+
     include_domains: Optional[List[str]] = field(default_factory=list)
+    
     icon: str = field(default="")
     Schema: ClassVar[Schema] = Schema
 
@@ -215,7 +230,7 @@ class HttpSettings:
         unknown = EXCLUDE
 
     enabled: bool
-    oidc_settings: Optional[OIDCSettings]
+    oidc_settings: Optional[OIDCSettings] = field(default_factory=dict)
     exempted_paths: Optional[ExemptedPaths] = field(default_factory=dict)
     #http_health_check: Optional[HTTPHealthCheck] # deprecated
     #http_redirect: Optional[HTTPRedirect] # deprecated

--- a/banyan/model/service_infra.py
+++ b/banyan/model/service_infra.py
@@ -1,0 +1,219 @@
+import json
+
+from marshmallow_dataclass import dataclass
+from banyan.model.service import *
+
+
+@dataclass
+class ServiceInfraBase:
+    name: str = ""
+    description: str = "ServiceInfraBase"
+    # deployment model
+    cluster: str = ""
+    access_tier: str = ""
+    connector: str = ""
+    # connectivity
+    domain: str = ""
+    port: int = 8443
+    # backend
+    backend_domain: str = ""
+    backend_port: int = None
+    backend_http_connect: bool = False
+    backend_dns_override_for_domain: str = ""
+    # client
+    client_user_override: bool = True
+    # client proxy
+    client_banyanproxy_mode: str = ""
+    client_listen_port: int = None
+    # client ssh
+    client_ssh_auth: str = ""
+    client_ssh_host_directive: str = ""
+    client_ssh_write_config: bool = True
+    # client k8s
+    client_kube_cluster_name: str = ""
+    client_kube_ca_key: str = ""
+    # TODO: backend_allowed_hostnames, backend_allowed_cidrs, client_domains_to_proxy
+    # TODO: ssh wildcard logic
+    # in ui but ignore here - backend_target_delimiter, backend_domain_templating
+
+    # check obj
+    def __post_init__(self):
+        # basics
+        if self.name == "" or self.domain == "":
+            raise Exception("Configuration Error! Need to specify name, domain, backend_domain, backend_port.")
+        # deployment model
+        if self.cluster == "":
+            raise Exception("Configuration Error! Need to specify cluster.")
+        if (self.connector == "" and self.access_tier == "") or (self.connector != "" and self.access_tier != ""):
+            raise Exception("Configuration Error! Need to specify either access_tier or connector.")
+        # deployment model = self-hosted access-tier
+        if self.access_tier != "":
+            self.connector = ""
+        # deployment model = global-edge
+        if self.connector != "":
+            self.access_tier = "*"
+        # backend connectivity
+        if (self.backend_http_connect and self.backend_domain != "") or (not self.backend_http_connect and self.backend_domain == ""):
+            raise Exception("Configuration Error! Need to specify either backend_http_connect or backend_domain.")
+
+    def service_obj(self) -> Service:
+        tags = Tags(
+            template = ServiceTemplate.TCP,
+            service_app_type = "", # child will override
+            user_facing = True,
+            protocol = "tcp",
+            domain = self.domain,
+            port = self.port,
+            allow_user_override = self.client_user_override,
+        )
+        metadata = Metadata(
+            name = self.name,
+            friendly_name = self.name,
+            description = self.description,
+            cluster = self.cluster,
+            tags = tags
+        )
+        frontend_address = FrontendAddress(
+            port = self.port,
+            cidr = ""
+        )
+        attributes = Attributes(
+            tls_sni = [self.domain],
+            frontend_addresses = [frontend_address],
+            host_tag_selector = [
+                { "com.banyanops.hosttag.site_name": self.access_tier }
+            ]
+        )
+        target = BackendTarget(
+            name = self.backend_domain,
+            port = self.backend_port,
+            tls = False,
+        )
+        backend = Backend(
+            target = target,
+            http_connect = self.backend_http_connect,
+            connector_name = self.connector
+        )
+        cert_settings = CertSettings(
+            dns_names = [self.domain],
+        )
+        http_settings = HttpSettings(
+            enabled = False
+        )
+        spec = Spec(
+            attributes = attributes,
+            backend = backend,
+            cert_settings = cert_settings,
+            http_settings = http_settings
+        )
+        service = Service(
+            kind = "BanyanService",
+            apiVersion = "rbac.banyanops.com/v1",
+            type = "origin",
+            metadata = metadata, 
+            spec = spec
+        )
+        return service
+
+
+@dataclass
+class ServiceInfraSSH(ServiceInfraBase):
+    def __post_init__(self):
+        super().__post_init__()
+        if self.client_ssh_auth == "":
+            self.client_ssh_auth = ServiceClientCertificateType.TRUSTCERT
+
+    def service_obj(self) -> Service:
+        svc = super().service_obj()
+        # tags
+        svc.metadata.tags.service_app_type = ServiceAppType.SSH
+        svc.metadata.tags.ssh_service_type = self.client_ssh_auth
+        svc.metadata.tags.ssh_host_directive = self.client_ssh_host_directive
+        svc.metadata.tags.write_ssh_config = self.client_ssh_write_config
+        # proxy mode
+        svc.metadata.tags.ssh_chain_mode = self.backend_http_connect
+        return svc
+
+@dataclass
+class ServiceInfraRDP(ServiceInfraBase):
+    def __post_init__(self):
+        super().__post_init__()
+
+    def service_obj(self) -> Service:
+        svc = super().service_obj()
+        # tags
+        svc.metadata.tags.service_app_type = ServiceAppType.RDP
+        svc.metadata.tags.app_listen_port = self.client_listen_port
+        # proxy mode
+        svc.metadata.tags.banyanproxy_mode = ServiceClientProxyMode.RDPGATEWAY if self.backend_http_connect else ServiceClientProxyMode.TCP
+        return svc
+
+@dataclass
+class ServiceInfraK8s(ServiceInfraBase):
+    def __post_init__(self):
+        super().__post_init__()
+        self.backend_http_connect = True
+        if self.client_kube_cluster_name == "" or self.client_kube_ca_key == "" or self.backend_dns_override_for_domain == "":
+            raise Exception("Configuration Error! Need to specify client_kube_cluster_name, client_kube_ca_key, backend_dns_override_for_domain.")
+
+    def service_obj(self) -> Service:
+        svc = super().service_obj()
+        # tags
+        svc.metadata.tags.service_app_type = ServiceAppType.K8S
+        svc.metadata.tags.app_listen_port = self.client_listen_port
+        # proxy mode
+        svc.metadata.tags.banyanproxy_mode = ServiceClientProxyMode.CHAIN
+
+        return svc
+
+@dataclass
+class ServiceInfraDatabase(ServiceInfraBase):
+    def __post_init__(self):
+        super().__post_init__()            
+
+    def service_obj(self) -> Service:
+        svc = super().service_obj()
+        # tags
+        svc.metadata.tags.service_app_type = ServiceAppType.DATABASE
+        svc.metadata.tags.app_listen_port = self.client_listen_port
+        # proxy mode
+        svc.metadata.tags.banyanproxy_mode = ServiceClientProxyMode.CHAIN if self.backend_http_connect else ServiceClientProxyMode.TCP
+        return svc
+
+@dataclass
+class ServiceInfraTCP(ServiceInfraBase):
+    def __post_init__(self):
+        super().__post_init__()            
+
+    def service_obj(self) -> Service:
+        svc = super().service_obj()
+        # tags
+        svc.metadata.tags.service_app_type = ServiceAppType.TCP
+        svc.metadata.tags.app_listen_port = self.client_listen_port
+        # proxy mode
+        svc.metadata.tags.banyanproxy_mode = ServiceClientProxyMode.CHAIN if self.backend_http_connect else ServiceClientProxyMode.TCP
+        return svc
+
+
+if __name__ == '__main__':
+    svc_ssh = ServiceInfraSSH(
+        name = "test-infra-ssh",
+        cluster = "cluster1",
+        access_tier = "foo",
+        domain = "test-infra-ssh.example.com",
+        backend_http_connect = True,
+        client_ssh_host_directive = "10.10.1.0/24"
+    )
+    print(svc_ssh.service_obj())
+
+    svc_tcp_at = ServiceInfraTCP(
+        name = "test-infra-tcp",
+        cluster = "cluster1",
+        access_tier = "foo",
+        domain = "test-infra-tcp.example.com",
+        backend_domain = "10.10.1.1",
+        backend_port = 6006,
+    )
+    print(svc_tcp_at.service_obj())
+    #obj = svc_tcp_at.service_obj()
+    #print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))

--- a/banyan/model/service_infra.py
+++ b/banyan/model/service_infra.py
@@ -51,10 +51,10 @@ class ServiceInfraBase:
         default=False,
         metadata={'required': True, 'help': 'Client will specify backend address & port using HTTP Connect; set to False if using Fixed Backend Domain connectivity'}
         )
-    # client proxy (not used by SSH)
+    # client proxy
     client_banyanproxy_listen_port: int = field(
         default=None,
-        metadata={'help': 'Local listen port to be used by client proxy; if not specified a random local port will be used'}
+        metadata={'help': 'Local listen port to be used by client proxy; if not specified, a random local port will be used'}
         )
     # TODO: backend_allowed_hostnames, backend_allowed_cidrs
     # TODO: ssh wildcard logic
@@ -183,7 +183,7 @@ class ServiceInfraSSH(ServiceInfraBase):
         )
     client_banyanproxy_listen_port: int = field(
         default=None,
-        metadata={'ignored': True}
+        metadata={'ignored': True, 'help': 'For SSH, banyanproxy uses stdin instead of a local port'}
         )
 
     def service_obj(self) -> Service:
@@ -203,19 +203,19 @@ class ServiceInfraSSH(ServiceInfraBase):
 class ServiceInfraK8S(ServiceInfraBase):
     backend_connectivity: str = field(
         default=None,
-        metadata={'ignored': True}
+        metadata={'ignored': True, 'help': 'For K8S, we use Client Specified connectivity'}
     )
     backend_domain: str = field(
         default='',
-        metadata={'ignored': True}
+        metadata={'ignored': True, 'help': 'For K8S, we use Client Specified connectivity'}
         )
     backend_port: int = field(
         default='',
-        metadata={'ignored': True}
+        metadata={'ignored': True, 'help': 'For K8S, we use Client Specified connectivity'}
         )
     backend_http_connect: bool = field(
         default=True,
-        metadata={'ignored': True}
+        metadata={'ignored': True, 'help': 'For K8S, we use Client Specified connectivity'}
         )
     backend_dns_override_for_domain: str = field(
         default="",
@@ -267,7 +267,7 @@ class ServiceInfraDatabase(ServiceInfraBase):
     client_banyanproxy_allowed_domains: list = field(
         default_factory=list,
         metadata={'help': 'Restrict which domains can be proxied through the banyanproxy; only used with Client Specified connectivity'}
-        )        
+        )
 
     def service_obj(self) -> Service:
         svc = super().service_obj()

--- a/banyan/model/service_infra.py
+++ b/banyan/model/service_infra.py
@@ -191,6 +191,8 @@ class ServiceInfraK8S(ServiceInfraBase):
 @dataclass
 class ServiceInfraDatabase(ServiceInfraBase):
     def __post_init__(self):
+        if self.client_tcp_domains_to_proxy is None:
+            self.client_tcp_domains_to_proxy = []
         super().__post_init__()            
 
     def service_obj(self) -> Service:
@@ -198,6 +200,7 @@ class ServiceInfraDatabase(ServiceInfraBase):
         # tags
         svc.metadata.tags.service_app_type = str(ServiceAppType.DATABASE)
         svc.metadata.tags.app_listen_port = str(self.client_listen_port)
+        svc.metadata.tags.include_domains = self.client_tcp_domains_to_proxy
         # proxy mode
         svc.metadata.tags.banyanproxy_mode = str(ServiceClientProxyMode.CHAIN) if self.backend_http_connect else str(ServiceClientProxyMode.TCP)
         return svc

--- a/banyan/model/service_web.py
+++ b/banyan/model/service_web.py
@@ -1,44 +1,97 @@
-import json
+import dataclasses
 from marshmallow_dataclass import dataclass
 from banyan.model.service import *
 
 @dataclass
 class ServiceWebStandard:
-    name: str = ""
-    description: str = "ServiceWebStandard"
+    name: str = field(
+        default=None,
+        metadata={'required': True, 'help': 'Name of the service; use lowercase alphanumeric characters or "-"'}
+        )
+    description: str = field(
+        default='ServiceWebStandard',
+        metadata={'help': 'Description of the service'}
+        )
     # deployment model
-    cluster: str = ""
-    access_tier: str = ""
-    connector: str = ""
-    # connectivity
-    domain: str = ""
-    port: int = 443
-    letsencrypt: bool = False
+    cluster: str = field(
+        default=None,
+        metadata={'required': True, 'help': 'Name of the cluster used for your deployment; for Global Edge set to "global-edge", for Private Edge set to "cluster1"'}
+        )
+    access_tier: str = field(
+        default=None,
+        metadata={'required': True, 'help': 'Name of the access_tier which will proxy requests to your service backend; set to "" if using Global Edge deployment'}
+        )
+    connector: str = field(
+        default=None,
+        metadata={'required': True, 'help': 'Name of the connector which will proxy requests to your service backend; set to "" if using Private Edge deployment'}
+        )
+    # frontend
+    domain: str = field(
+        default=None,
+        metadata={'required': True, 'help': 'The external-facing network address for this service; ex. website.example.com'}
+        )
+    port: int = field(
+        default=443,
+        metadata={'ignored': True, 'help': 'The external-facing port for this service; set to 443 for hosted websites'}
+        )
+    letsencrypt: bool = field(
+        default=False,
+        metadata={'help': 'Use a Public CA-issued server certificate instead of a Private CA-issued one'}
+        )
     # backend
-    backend_domain: str = ""
-    backend_port: int = None
-    backend_tls: bool = False
-    backend_tls_insecure: bool = False
+    backend_domain: str = field(
+        default=None,
+        metadata={'required': True, 'help': 'The internal network address where this service is hosted; ex. 192.168.1.2'}
+        )
+    backend_port: int = field(
+        default=None,
+        metadata={'required': True, 'help': 'The internal port where this service is hosted'}
+        )
+    backend_tls: bool = field(
+        default=False,
+        metadata={'help': 'Indicates the backend server uses TLS'}
+        )
+    backend_tls_insecure: bool = field(
+        default=False,
+        metadata={'help': 'Indicates the backend server does not validate the TLS certficate'}
+        )
     # TODO: cors, exemptions, custom_headers, service_accounts
     # in ui but ignore here - description_link, icon, show_in_catalog, backend_tls_client_cert
 
-    # check obj
-    def __post_init__(self):
+    # sanity check params and update dependencies
+    def initialize(self):
         # basics
-        if self.name == "" or self.domain == "" or self.backend_domain == "" or self.backend_port == 0:
+        if not self.name or not self.domain or not self.backend_domain or not self.backend_port:
             raise Exception("Configuration Error! Need to specify name, domain, backend_domain, backend_port.")
         # deployment model
-        if self.cluster == "":
+        if not self.cluster:
             raise Exception("Configuration Error! Need to specify cluster.")
-        if (self.connector == "" and self.access_tier == "") or (self.connector != "" and self.access_tier != ""):
+        if (not self.connector and not self.access_tier) or (self.connector and self.access_tier):
             raise Exception("Configuration Error! Need to specify either access_tier or connector.")
         # deployment model = self-hosted access-tier
-        if self.access_tier != "":
+        if self.access_tier:
             self.connector = ""
         # deployment model = global-edge
-        if self.connector != "":
+        if self.connector:
             self.access_tier = "*"
 
+    # argparse arguments in controller
+    @classmethod
+    def arguments(cls) -> list:
+        args = []
+        flds = dataclasses.fields(globals()[cls.__name__])
+        for fld in flds:
+            if fld.metadata.get("ignored"):
+                continue           
+            # optional args are prefixed with "--", and should have valid defaults
+            argname = fld.name if fld.metadata.get("required") else ("--" + fld.name)
+            # help text should contain type
+            helptext = f'(type: {fld.type.__name__}) {fld.metadata.get("help")}'
+            arg = ([argname], dict(type = fld.type, help = helptext))
+            args.append(arg)
+        return args
+
+    # create a Service object
     def service_obj(self) -> Service:
         tags = Tags(
             template = str(ServiceTemplate.WEB),

--- a/banyan/model/service_web.py
+++ b/banyan/model/service_web.py
@@ -41,23 +41,25 @@ class ServiceWebStandard:
 
     def service_obj(self) -> Service:
         tags = Tags(
-            template = ServiceTemplate.WEB,
-            service_app_type = ServiceAppType.WEB,
-            user_facing = True,
+            template = str(ServiceTemplate.WEB),
+            user_facing = "true",
             protocol = "https",
             domain = self.domain,
-            port = self.port
+            port = str(self.port),
+            icon = "",
+            service_app_type = str(ServiceAppType.WEB),
+            description_link = ""
         )
         metadata = Metadata(
             name = self.name,
-            friendly_name = self.name,
+            friendly_name = None,
             description = self.description,
             cluster = self.cluster,
             tags = tags
         )
         frontend_address = FrontendAddress(
-            port = self.port,
-            cidr = ""
+            port = str(self.port),
+            cidr = None
         )
         attributes = Attributes(
             tls_sni = [self.domain],
@@ -68,7 +70,7 @@ class ServiceWebStandard:
         )
         target = BackendTarget(
             name = self.backend_domain,
-            port = self.backend_port,
+            port = str(self.backend_port),
             tls = self.backend_tls,
             tls_insecure = self.backend_tls_insecure
         )
@@ -84,9 +86,13 @@ class ServiceWebStandard:
             enabled = True,
             service_domain_name = "https://" + self.domain
         )
+        exempted_paths = ExemptedPaths(
+            enabled = False
+        )
         http_settings = HttpSettings(
             enabled = True,
-            oidc_settings = oidc_settings
+            oidc_settings = oidc_settings,
+            exempted_paths = exempted_paths
         )
         spec = Spec(
             attributes = attributes,
@@ -98,45 +104,7 @@ class ServiceWebStandard:
             kind = "BanyanService",
             apiVersion = "rbac.banyanops.com/v1",
             type = "origin",
-            metadata = metadata, 
+            metadata = metadata,
             spec = spec
         )
         return service
-
-
-if __name__ == '__main__':
-    svc_web_at = ServiceWebStandard(
-        name = "test-web-at",
-        cluster = "cluster1",
-        access_tier = "foo",
-        domain = "test-web-at.example.com",
-        backend_domain = "10.10.1.1",
-        backend_port = 8080
-    )
-    obj = svc_web_at.service_obj()
-    print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))
-    
-    svc_web_conn = ServiceWebStandard(
-        name = "test-web-conn",
-        cluster = "global-edge",
-        connector = "foo",
-        domain = "test-web-conn" + ".orgname.banyanops.com",
-        backend_domain = "10.10.1.1",
-        backend_port = 8080
-    )
-    obj = svc_web_conn.service_obj()
-    print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))
-
-    svc_web_certs = ServiceWebStandard(
-        name = "test-web-certs",
-        cluster = "global-edge",
-        connector = "foo",
-        domain = "test-web-certs" + ".orgname.banyanops.com",
-        letsencrypt = True,
-        backend_domain = "10.10.1.1",
-        backend_port = 8080,
-        backend_tls = True,
-        backend_tls_insecure = True
-    )
-    obj = svc_web_conn.service_obj()
-    print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))

--- a/banyan/model/service_web.py
+++ b/banyan/model/service_web.py
@@ -59,7 +59,7 @@ class ServiceWebStandard:
     # in ui but ignore here - description_link, icon, show_in_catalog, backend_tls_client_cert
 
     # sanity check params and update dependencies
-    def initialize(self):
+    def _initialize(self):
         # basics
         if not self.name or not self.domain or not self.backend_domain or not self.backend_port:
             raise Exception("Configuration Error! Need to specify name, domain, backend_domain, backend_port.")
@@ -93,6 +93,7 @@ class ServiceWebStandard:
 
     # create a Service object
     def service_obj(self) -> Service:
+        self._initialize()
         tags = Tags(
             template = str(ServiceTemplate.WEB),
             user_facing = "true",

--- a/banyan/model/service_web.py
+++ b/banyan/model/service_web.py
@@ -1,0 +1,109 @@
+from marshmallow_dataclass import dataclass
+from banyan.model.service import *
+
+@dataclass
+class ServiceWebStandard:
+    name: str
+    description: str
+    
+    cluster: str
+    access_tier: str
+    connector: str
+    
+    domain: str
+    backend_domain: str
+    backend_port: int
+    
+    # solid defaults
+    port: int = 443
+    letsencrypt: bool = False
+    backend_tls: bool = False
+    backend_tls_insecure: bool = False
+
+    # todo - cors, exemptions, custom_headers, service_accounts
+    # in ui but ignore here - description_link, icon, show_in_catalog, backend_tls_client_cert
+
+    def create_service_obj(self) -> Service:
+        # global edge deployment model if connector is set
+        access_tier_selector = "com.banyanops.hosttag.site_name"
+        access_tier_value = self.access_tier
+        if self.connector:
+            access_tier_value = "*"
+
+        tags = Tags(
+            template = ServiceTemplate.WEB,
+            service_app_type = ServiceAppType.WEB,
+            user_facing = True,
+            protocol = "HTTPS",
+            domain = self.domain,
+            port = self.port
+        )
+        metadata = Metadata(
+            name = self.name,
+            friendly_name = self.name,
+            description = self.description,
+            cluster = self.cluster,
+            tags = tags
+        )
+        frontend_address = FrontendAddress(
+            port = self.port,
+            cidr = ""
+        )
+        attributes = Attributes(
+            tls_sni = [self.domain],
+            frontend_addresses = [frontend_address],
+            host_tag_selector = [
+                {access_tier_selector: access_tier_value}
+            ]
+        )
+        target = BackendTarget(
+            name = self.backend_domain,
+            port = self.backend_port,
+            tls = self.backend_tls,
+            tls_insecure = self.backend_tls_insecure
+        )
+        backend = Backend(
+            target = target,
+            connector_name = self.connector
+        )
+        cert_settings = CertSettings(
+            dns_names = [self.domain],
+            letsencrypt = self.letsencrypt
+        )
+        oidc_settings = OIDCSettings(
+            enabled = True,
+            service_domain_name = "https://" + self.domain
+        )
+        http_settings = HttpSettings(
+            enabled = True,
+            oidc_settings = oidc_settings
+        )
+        spec = Spec(
+            attributes = attributes,
+            backend = backend,
+            cert_settings = cert_settings,
+            http_settings = http_settings
+        )
+        service = Service(
+            kind = "BanyanService",
+            apiVersion = "rbac.banyanops.com/v1",
+            type = "origin",
+            metadata = metadata, 
+            spec = spec
+        )
+        return service
+
+
+if __name__ == '__main__':
+    svc_web = ServiceWebStandard(
+        name = "test",
+        description = "test",
+        cluster = "cl1",
+        access_tier = "",
+        connector = "myconn",
+        domain = "test.example.com",
+        backend_domain = "10.10.1.1",
+        backend_port = 8080
+    )
+    svc_obj = svc_web.create_service_obj()
+    print(svc_obj)

--- a/banyan/model/service_web.py
+++ b/banyan/model/service_web.py
@@ -1,3 +1,4 @@
+import json
 from marshmallow_dataclass import dataclass
 from banyan.model.service import *
 
@@ -112,9 +113,9 @@ if __name__ == '__main__':
         backend_domain = "10.10.1.1",
         backend_port = 8080
     )
-    svc_obj = svc_web_at.service_obj()
-    print(svc_obj)
-
+    obj = svc_web_at.service_obj()
+    print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))
+    
     svc_web_conn = ServiceWebStandard(
         name = "test-web-conn",
         cluster = "global-edge",
@@ -123,6 +124,19 @@ if __name__ == '__main__':
         backend_domain = "10.10.1.1",
         backend_port = 8080
     )
-    svc_obj = svc_web_conn.service_obj()
-    print(svc_obj)
+    obj = svc_web_conn.service_obj()
+    print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))
 
+    svc_web_certs = ServiceWebStandard(
+        name = "test-web-certs",
+        cluster = "global-edge",
+        connector = "foo",
+        domain = "test-web-certs" + ".orgname.banyanops.com",
+        letsencrypt = True,
+        backend_domain = "10.10.1.1",
+        backend_port = 8080,
+        backend_tls = True,
+        backend_tls_insecure = True
+    )
+    obj = svc_web_conn.service_obj()
+    print(json.dumps(Service.Schema().dump(obj), indent=2, sort_keys=True))

--- a/tests/data/service_specs/database-conn.json
+++ b/tests/data/service_specs/database-conn.json
@@ -1,0 +1,111 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "database-conn",
+        "description": "pybanyan database-conn",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-database-conn.tdupnsan.getbnn.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "DATABASE",
+            "banyanproxy_mode": "TCP",
+            "app_listen_port": "9299",
+            "allow_user_override": true,
+            "description_link": "",
+            "include_domains": []
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-database-conn.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.1.123",
+                "port": "3306",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-database-conn.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/k8s-conn.json
+++ b/tests/data/service_specs/k8s-conn.json
@@ -1,0 +1,122 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "k8s-conn",
+        "description": "pybanyan k8s-conn",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-k8s-conn.tdupnsan.getbnn.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "K8S",
+            "banyanproxy_mode": "CHAIN",
+            "app_listen_port": "9199",
+            "allow_user_override": true,
+            "kube_cluster_name": "eks-hero",
+            "kube_ca_key": "AAAA1234",
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-k8s-conn.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "",
+                "port": "",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {
+                "test-k8s-conn.tdupnsan.getbnn.com": "myoidcproxy.amazonaws.com"
+            },
+            "whitelist": [],
+            "allow_patterns": [
+                {
+                    "hostnames": [
+                        "test-k8s-conn.tdupnsan.getbnn.com"
+                    ]
+                }
+            ],
+            "http_connect": true,
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-k8s-conn.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/rdp-collection.json
+++ b/tests/data/service_specs/rdp-collection.json
@@ -1,0 +1,114 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "rdp-collection",
+        "description": "pybanyan rdp-collection",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-rdp-collection.tdupnsan.getbnn.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "RDP",
+            "banyanproxy_mode": "RDPGATEWAY",
+            "app_listen_port": "9108",
+            "allow_user_override": true,
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-rdp-collection.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "",
+                "port": "",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "allow_patterns": [
+                {}
+            ],
+            "http_connect": true,
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-rdp-collection.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/rdp-conn.json
+++ b/tests/data/service_specs/rdp-conn.json
@@ -1,0 +1,110 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "rdp-conn",
+        "description": "pybanyan rdp-conn",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-rdp-conn.tdupnsan.getbnn.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "RDP",
+            "banyanproxy_mode": "TCP",
+            "app_listen_port": "9109",
+            "allow_user_override": true,
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-rdp-conn.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.2.1",
+                "port": "3309",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-rdp-conn.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/ssh-at.json
+++ b/tests/data/service_specs/ssh-at.json
@@ -1,0 +1,115 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "ssh-at",
+        "description": "pybanyan ssh-at",
+        "cluster": "cluster1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-ssh-at.bar.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "SSH",
+            "ssh_service_type": "TRUSTCERT",
+            "write_ssh_config": true,
+            "ssh_chain_mode": true,
+            "ssh_host_directive": "10.10.1.*",
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-ssh-at.bar.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "gcp-wg"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "",
+                "port": "",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "allow_patterns": [
+                {}
+            ],
+            "http_connect": true,
+            "connector_name": ""
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-ssh-at.bar.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/ssh-conn.json
+++ b/tests/data/service_specs/ssh-conn.json
@@ -1,0 +1,111 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "ssh-conn",
+        "description": "pybanyan ssh-conn",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-ssh-conn.tdupnsan.getbnn.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "SSH",
+            "ssh_service_type": "TRUSTCERT",
+            "write_ssh_config": true,
+            "ssh_chain_mode": false,
+            "ssh_host_directive": "",
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-ssh-conn.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.1.1",
+                "port": "22",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-ssh-conn.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/tcp-at.json
+++ b/tests/data/service_specs/tcp-at.json
@@ -1,0 +1,111 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "tcp-at",
+        "description": "pybanyan tcp-at",
+        "cluster": "cluster1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-tcp-at.bar.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "GENERIC",
+            "banyanproxy_mode": "TCP",
+            "app_listen_port": "9119",
+            "allow_user_override": true,
+            "description_link": "",
+            "include_domains": []
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-tcp-at.bar.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "gcp-wg"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.1.6",
+                "port": "6006",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": ""
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-tcp-at.bar.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/tcp-conn.json
+++ b/tests/data/service_specs/tcp-conn.json
@@ -1,0 +1,111 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "tcp-conn",
+        "description": "pybanyan tcp-conn",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "TCP_USER",
+            "user_facing": "true",
+            "protocol": "tcp",
+            "domain": "test-tcp-conn.tdupnsan.getbnn.com",
+            "port": "8443",
+            "icon": "",
+            "service_app_type": "GENERIC",
+            "banyanproxy_mode": "TCP",
+            "app_listen_port": "9118",
+            "allow_user_override": true,
+            "description_link": "",
+            "include_domains": []
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-tcp-conn.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "8443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.1.100",
+                "port": "5000",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-tcp-conn.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": false,
+            "oidc_settings": {
+                "enabled": false,
+                "service_domain_name": "",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false,
+                "patterns": [
+                    {
+                        "hosts": [
+                            {
+                                "origin_header": [],
+                                "target": []
+                            }
+                        ],
+                        "methods": [],
+                        "paths": [],
+                        "mandatory_headers": []
+                    }
+                ]
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/web-at.json
+++ b/tests/data/service_specs/web-at.json
@@ -1,0 +1,94 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "web-at",
+        "description": "pybanyan web-at",
+        "cluster": "cluster1",
+        "tags": {
+            "template": "WEB_USER",
+            "user_facing": "true",
+            "protocol": "https",
+            "domain": "test-web-at.bar.com",
+            "port": "443",
+            "icon": "",
+            "service_app_type": "WEB",
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-web-at.bar.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "gcp-wg"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.1.1",
+                "port": "8000",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": ""
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-web-at.bar.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": true,
+            "oidc_settings": {
+                "enabled": true,
+                "service_domain_name": "https://test-web-at.bar.com",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/web-certs.json
+++ b/tests/data/service_specs/web-certs.json
@@ -1,0 +1,94 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "web-certs",
+        "description": "pybanyan web-certs",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "WEB_USER",
+            "user_facing": "true",
+            "protocol": "https",
+            "domain": "test-web-certs.tdupnsan.getbnn.com",
+            "port": "443",
+            "icon": "",
+            "service_app_type": "WEB",
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-web-certs.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "foo.backend.int",
+                "port": "8080",
+                "tls": true,
+                "tls_insecure": true,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-web-certs.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": true
+        },
+        "http_settings": {
+            "enabled": true,
+            "oidc_settings": {
+                "enabled": true,
+                "service_domain_name": "https://test-web-certs.tdupnsan.getbnn.com",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/data/service_specs/web-conn.json
+++ b/tests/data/service_specs/web-conn.json
@@ -1,0 +1,94 @@
+{
+    "kind": "BanyanService",
+    "apiVersion": "rbac.banyanops.com/v1",
+    "type": "origin",
+    "metadata": {
+        "name": "web-conn",
+        "description": "pybanyan web-conn",
+        "cluster": "managed-cl-edge1",
+        "tags": {
+            "template": "WEB_USER",
+            "user_facing": "true",
+            "protocol": "https",
+            "domain": "test-web-conn.tdupnsan.getbnn.com",
+            "port": "443",
+            "icon": "",
+            "service_app_type": "WEB",
+            "description_link": ""
+        }
+    },
+    "spec": {
+        "attributes": {
+            "tls_sni": [
+                "test-web-conn.tdupnsan.getbnn.com"
+            ],
+            "frontend_addresses": [
+                {
+                    "cidr": "",
+                    "port": "443"
+                }
+            ],
+            "host_tag_selector": [
+                {
+                    "com.banyanops.hosttag.site_name": "*"
+                }
+            ],
+            "disable_private_dns": false
+        },
+        "backend": {
+            "target": {
+                "name": "10.10.1.1",
+                "port": "8080",
+                "tls": false,
+                "tls_insecure": false,
+                "client_certificate": false
+            },
+            "dns_overrides": {},
+            "whitelist": [],
+            "connector_name": "test-connector"
+        },
+        "cert_settings": {
+            "dns_names": [
+                "test-web-conn.tdupnsan.getbnn.com"
+            ],
+            "custom_tls_cert": {
+                "enabled": false,
+                "cert_file": "",
+                "key_file": ""
+            },
+            "letsencrypt": false
+        },
+        "http_settings": {
+            "enabled": true,
+            "oidc_settings": {
+                "enabled": true,
+                "service_domain_name": "https://test-web-conn.tdupnsan.getbnn.com",
+                "post_auth_redirect_path": "",
+                "api_path": "",
+                "trust_callbacks": null,
+                "suppress_device_trust_verification": false
+            },
+            "http_health_check": {
+                "enabled": false,
+                "addresses": null,
+                "method": "",
+                "path": "",
+                "user_agent": "",
+                "from_address": [],
+                "https": false
+            },
+            "http_redirect": {
+                "enabled": false,
+                "addresses": null,
+                "from_address": null,
+                "url": "",
+                "status_code": 0
+            },
+            "exempted_paths": {
+                "enabled": false
+            },
+            "headers": {}
+        },
+        "client_cidrs": []
+    }
+}

--- a/tests/service_specs/__init__.py
+++ b/tests/service_specs/__init__.py
@@ -1,0 +1,15 @@
+import unittest
+
+from banyan.model.service import Service
+
+def load_service_spec(filespec: str) -> str:
+    filespec = "tests/data/service_specs/" + filespec
+    with open(filespec) as f:
+        return f.read()
+
+def assert_specs_equal(test_case: unittest.TestCase, ref_obj: Service, svc_obj: Service):
+    test_case.assertDictEqual(vars(ref_obj.metadata), vars(svc_obj.metadata))
+    test_case.assertDictEqual(vars(ref_obj.spec.attributes), vars(svc_obj.spec.attributes))
+    test_case.assertDictEqual(vars(ref_obj.spec.backend), vars(svc_obj.spec.backend))
+    test_case.assertDictEqual(vars(ref_obj.spec.cert_settings), vars(svc_obj.spec.cert_settings))
+    test_case.assertDictEqual(vars(ref_obj.spec.http_settings), vars(svc_obj.spec.http_settings))

--- a/tests/service_specs/test_infra.py
+++ b/tests/service_specs/test_infra.py
@@ -16,7 +16,6 @@ class ServiceInfraSSHTest(unittest.TestCase):
             backend_http_connect = True,
             client_ssh_host_directive = "10.10.1.*"
         )
-        svc_ssh_at.initialize()
         svc_obj: Service = svc_ssh_at.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("ssh-at.json"))
         #print()
@@ -34,7 +33,6 @@ class ServiceInfraSSHTest(unittest.TestCase):
             backend_domain = "10.10.1.1",
             backend_port = 22
         )
-        svc_ssh_conn.initialize()
         svc_obj: Service = svc_ssh_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("ssh-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -54,7 +52,6 @@ class ServiceInfraK8STest(unittest.TestCase):
             client_kube_cluster_name = "eks-hero",
             client_kube_ca_key = "AAAA1234"
         )
-        svc_k8s_conn.initialize()
         svc_obj: Service = svc_k8s_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("k8s-conn.json"))
         #print()
@@ -76,7 +73,6 @@ class ServiceInfraRDPTest(unittest.TestCase):
             backend_port = 3309,
             client_banyanproxy_listen_port = 9109
         )
-        svc_rdp_conn.initialize()
         svc_obj: Service = svc_rdp_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("rdp-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -91,7 +87,6 @@ class ServiceInfraRDPTest(unittest.TestCase):
             backend_http_connect = True,
             client_banyanproxy_listen_port = 9108
         )
-        svc_rdp_collection.initialize()
         svc_obj: Service = svc_rdp_collection.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("rdp-collection.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -110,7 +105,6 @@ class ServiceInfraDatabaseTest(unittest.TestCase):
             backend_port = 3306,
             client_banyanproxy_listen_port = 9299
         )
-        svc_database_conn.initialize()
         svc_obj: Service = svc_database_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("database-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -129,7 +123,6 @@ class ServiceInfraTCPTest(unittest.TestCase):
             backend_port = 6006,
             client_banyanproxy_listen_port = 9119
         )
-        svc_tcp_at.initialize()
         svc_obj: Service = svc_tcp_at.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-at.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -145,7 +138,6 @@ class ServiceInfraTCPTest(unittest.TestCase):
             backend_port = 5000,
             client_banyanproxy_listen_port = 9118
         )
-        svc_tcp_conn.initialize()
         svc_obj: Service = svc_tcp_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)

--- a/tests/service_specs/test_infra.py
+++ b/tests/service_specs/test_infra.py
@@ -38,21 +38,35 @@ class ServiceInfraSSHTest(unittest.TestCase):
         assert_specs_equal(self, ref_obj, svc_obj)
 
 
-class ServiceInfraTCPTest(unittest.TestCase):
+class ServiceInfraRDPTest(unittest.TestCase):
 
-    def test_tcp_at(self):
-        svc_tcp_at = ServiceInfraTCP(
-            name = "tcp-at",
-            description = "pybanyan tcp-at",
-            cluster = "cluster1",
-            access_tier = "gcp-wg",
-            domain = "test-tcp-at.bar.com",
-            backend_domain = "10.10.1.6",
-            backend_port = 6006,
-            client_listen_port = 9119
+    def test_rdp_conn(self):
+        svc_rdp_conn = ServiceInfraRDP(
+            name = "rdp-conn",
+            description = "pybanyan rdp-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-rdp-conn" + ".tdupnsan.getbnn.com",
+            backend_domain = "10.10.2.1",
+            backend_port = 3309,
+            client_listen_port = 9109
         )
-        svc_obj: Service = svc_tcp_at.service_obj()
-        ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-at.json"))
+        svc_obj: Service = svc_rdp_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("rdp-conn.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+    def test_rdp_collection(self):
+        svc_rdp_collection = ServiceInfraRDP(
+            name = "rdp-collection",
+            description = "pybanyan rdp-collection",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-rdp-collection" + ".tdupnsan.getbnn.com",
+            backend_http_connect = True,
+            client_listen_port = 9108
+        )
+        svc_obj: Service = svc_rdp_collection.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("rdp-collection.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
 
 
@@ -76,4 +90,54 @@ class ServiceInfraK8STest(unittest.TestCase):
         #print(ref_obj.spec.backend)
         #print(svc_obj.spec.backend)
         assert_specs_equal(self, ref_obj, svc_obj)
-        
+
+
+class ServiceInfraDatabaseTest(unittest.TestCase):
+
+    def test_database_at(self):
+        svc_database_conn = ServiceInfraDatabase(
+            name = "database-conn",
+            description = "pybanyan database-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-database-conn" + ".tdupnsan.getbnn.com",
+            backend_domain = "10.10.1.123",
+            backend_port = 3306,
+            client_listen_port = 9299
+        )
+        svc_obj: Service = svc_database_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("database-conn.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+
+class ServiceInfraTCPTest(unittest.TestCase):
+
+    def test_tcp_at(self):
+        svc_tcp_at = ServiceInfraTCP(
+            name = "tcp-at",
+            description = "pybanyan tcp-at",
+            cluster = "cluster1",
+            access_tier = "gcp-wg",
+            domain = "test-tcp-at.bar.com",
+            backend_domain = "10.10.1.6",
+            backend_port = 6006,
+            client_listen_port = 9119
+        )
+        svc_obj: Service = svc_tcp_at.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-at.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+    def test_tcp_conn(self):
+        svc_tcp_conn = ServiceInfraTCP(
+            name = "tcp-conn",
+            description = "pybanyan tcp-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-tcp-conn" + ".tdupnsan.getbnn.com",
+            backend_domain = "10.10.1.100",
+            backend_port = 5000,
+            client_listen_port = 9118
+        )
+        svc_obj: Service = svc_tcp_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-conn.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)

--- a/tests/service_specs/test_infra.py
+++ b/tests/service_specs/test_infra.py
@@ -16,6 +16,7 @@ class ServiceInfraSSHTest(unittest.TestCase):
             backend_http_connect = True,
             client_ssh_host_directive = "10.10.1.*"
         )
+        svc_ssh_at.initialize()
         svc_obj: Service = svc_ssh_at.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("ssh-at.json"))
         #print()
@@ -33,8 +34,32 @@ class ServiceInfraSSHTest(unittest.TestCase):
             backend_domain = "10.10.1.1",
             backend_port = 22
         )
+        svc_ssh_conn.initialize()
         svc_obj: Service = svc_ssh_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("ssh-conn.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+
+class ServiceInfraK8STest(unittest.TestCase):
+
+    def test_k8s_conn(self):
+        svc_k8s_conn = ServiceInfraK8S(
+            name = "k8s-conn",
+            description = "pybanyan k8s-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-k8s-conn" + ".tdupnsan.getbnn.com",
+            backend_dns_override_for_domain = "myoidcproxy.amazonaws.com",
+            client_banyanproxy_listen_port = 9199,
+            client_kube_cluster_name = "eks-hero",
+            client_kube_ca_key = "AAAA1234"
+        )
+        svc_k8s_conn.initialize()
+        svc_obj: Service = svc_k8s_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("k8s-conn.json"))
+        #print()
+        #print(ref_obj.spec.backend)
+        #print(svc_obj.spec.backend)
         assert_specs_equal(self, ref_obj, svc_obj)
 
 
@@ -49,8 +74,9 @@ class ServiceInfraRDPTest(unittest.TestCase):
             domain = "test-rdp-conn" + ".tdupnsan.getbnn.com",
             backend_domain = "10.10.2.1",
             backend_port = 3309,
-            client_listen_port = 9109
+            client_banyanproxy_listen_port = 9109
         )
+        svc_rdp_conn.initialize()
         svc_obj: Service = svc_rdp_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("rdp-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -63,35 +89,14 @@ class ServiceInfraRDPTest(unittest.TestCase):
             connector = "test-connector",
             domain = "test-rdp-collection" + ".tdupnsan.getbnn.com",
             backend_http_connect = True,
-            client_listen_port = 9108
+            client_banyanproxy_listen_port = 9108
         )
+        svc_rdp_collection.initialize()
         svc_obj: Service = svc_rdp_collection.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("rdp-collection.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
 
-
-class ServiceInfraK8STest(unittest.TestCase):
-
-    def test_k8s_conn(self):
-        svc_k8s_conn = ServiceInfraK8S(
-            name = "k8s-conn",
-            description = "pybanyan k8s-conn",
-            cluster = "managed-cl-edge1",
-            connector = "test-connector",
-            domain = "test-k8s-conn" + ".tdupnsan.getbnn.com",
-            backend_dns_override_for_domain = "myoidcproxy.amazonaws.com",
-            client_listen_port = 9199,
-            client_kube_cluster_name = "eks-hero",
-            client_kube_ca_key = "AAAA1234"
-        )
-        svc_obj: Service = svc_k8s_conn.service_obj()
-        ref_obj: Service = Service.Schema().loads(load_service_spec("k8s-conn.json"))
-        #print()
-        #print(ref_obj.spec.backend)
-        #print(svc_obj.spec.backend)
-        assert_specs_equal(self, ref_obj, svc_obj)
-
-
+        
 class ServiceInfraDatabaseTest(unittest.TestCase):
 
     def test_database_at(self):
@@ -103,8 +108,9 @@ class ServiceInfraDatabaseTest(unittest.TestCase):
             domain = "test-database-conn" + ".tdupnsan.getbnn.com",
             backend_domain = "10.10.1.123",
             backend_port = 3306,
-            client_listen_port = 9299
+            client_banyanproxy_listen_port = 9299
         )
+        svc_database_conn.initialize()
         svc_obj: Service = svc_database_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("database-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -121,8 +127,9 @@ class ServiceInfraTCPTest(unittest.TestCase):
             domain = "test-tcp-at.bar.com",
             backend_domain = "10.10.1.6",
             backend_port = 6006,
-            client_listen_port = 9119
+            client_banyanproxy_listen_port = 9119
         )
+        svc_tcp_at.initialize()
         svc_obj: Service = svc_tcp_at.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-at.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -136,8 +143,9 @@ class ServiceInfraTCPTest(unittest.TestCase):
             domain = "test-tcp-conn" + ".tdupnsan.getbnn.com",
             backend_domain = "10.10.1.100",
             backend_port = 5000,
-            client_listen_port = 9118
+            client_banyanproxy_listen_port = 9118
         )
+        svc_tcp_conn.initialize()
         svc_obj: Service = svc_tcp_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)

--- a/tests/service_specs/test_infra.py
+++ b/tests/service_specs/test_infra.py
@@ -1,0 +1,79 @@
+import unittest
+
+from banyan.model.service import Service
+from banyan.model.service_infra import ServiceInfraSSH, ServiceInfraRDP, ServiceInfraK8S, ServiceInfraDatabase, ServiceInfraTCP
+from tests.service_specs import load_service_spec, assert_specs_equal
+
+class ServiceInfraSSHTest(unittest.TestCase):
+
+    def test_ssh_at(self):
+        svc_ssh_at = ServiceInfraSSH(
+            name = "ssh-at",
+            description = "pybanyan ssh-at",
+            cluster = "cluster1",
+            access_tier = "gcp-wg",
+            domain = "test-ssh-at.bar.com",
+            backend_http_connect = True,
+            client_ssh_host_directive = "10.10.1.*"
+        )
+        svc_obj: Service = svc_ssh_at.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("ssh-at.json"))
+        #print()
+        #print(ref_obj.metadata.tags)
+        #print(svc_obj.metadata.tags)
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+    def test_ssh_conn(self):
+        svc_ssh_conn = ServiceInfraSSH(
+            name = "ssh-conn",
+            description = "pybanyan ssh-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-ssh-conn" + ".tdupnsan.getbnn.com",
+            backend_domain = "10.10.1.1",
+            backend_port = 22
+        )
+        svc_obj: Service = svc_ssh_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("ssh-conn.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+
+class ServiceInfraTCPTest(unittest.TestCase):
+
+    def test_tcp_at(self):
+        svc_tcp_at = ServiceInfraTCP(
+            name = "tcp-at",
+            description = "pybanyan tcp-at",
+            cluster = "cluster1",
+            access_tier = "gcp-wg",
+            domain = "test-tcp-at.bar.com",
+            backend_domain = "10.10.1.6",
+            backend_port = 6006,
+            client_listen_port = 9119
+        )
+        svc_obj: Service = svc_tcp_at.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("tcp-at.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+
+class ServiceInfraK8STest(unittest.TestCase):
+
+    def test_k8s_conn(self):
+        svc_k8s_conn = ServiceInfraK8S(
+            name = "k8s-conn",
+            description = "pybanyan k8s-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-k8s-conn" + ".tdupnsan.getbnn.com",
+            backend_dns_override_for_domain = "myoidcproxy.amazonaws.com",
+            client_listen_port = 9199,
+            client_kube_cluster_name = "eks-hero",
+            client_kube_ca_key = "AAAA1234"
+        )
+        svc_obj: Service = svc_k8s_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("k8s-conn.json"))
+        #print()
+        #print(ref_obj.spec.backend)
+        #print(svc_obj.spec.backend)
+        assert_specs_equal(self, ref_obj, svc_obj)
+        

--- a/tests/service_specs/test_web.py
+++ b/tests/service_specs/test_web.py
@@ -1,0 +1,55 @@
+import unittest
+
+from banyan.model.service import Service
+from banyan.model.service_web import ServiceWebStandard
+from tests.service_specs import load_service_spec, assert_specs_equal
+
+class ServiceWebTest(unittest.TestCase):
+
+    def test_web_at(self):
+        svc_web_at = ServiceWebStandard(
+            name = "web-at",
+            description = "pybanyan web-at",
+            cluster = "cluster1",
+            access_tier = "gcp-wg",
+            domain = "test-web-at.bar.com",
+            backend_domain = "10.10.1.1",
+            backend_port = 8000
+        )
+        svc_obj: Service = svc_web_at.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("web-at.json"))
+        #print()
+        #print(ref_obj.spec.backend)
+        #print(svc_obj.spec.backend)
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+    def test_web_conn(self):
+        svc_web_conn = ServiceWebStandard(
+            name = "web-conn",
+            description = "pybanyan web-conn",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-web-conn" + ".tdupnsan.getbnn.com",
+            backend_domain = "10.10.1.1",
+            backend_port = 8080
+        )
+        svc_obj = svc_web_conn.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("web-conn.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)
+
+    def test_web_certs(self):
+        svc_web_certs = ServiceWebStandard(
+            name = "web-certs",
+            description = "pybanyan web-certs",
+            cluster = "managed-cl-edge1",
+            connector = "test-connector",
+            domain = "test-web-certs" + ".tdupnsan.getbnn.com",
+            letsencrypt = True,
+            backend_domain = "foo.backend.int",
+            backend_port = 8080,
+            backend_tls = True,
+            backend_tls_insecure = True
+        )
+        svc_obj = svc_web_certs.service_obj()
+        ref_obj: Service = Service.Schema().loads(load_service_spec("web-certs.json"))
+        assert_specs_equal(self, ref_obj, svc_obj)

--- a/tests/service_specs/test_web.py
+++ b/tests/service_specs/test_web.py
@@ -16,7 +16,6 @@ class ServiceWebTest(unittest.TestCase):
             backend_domain = "10.10.1.1",
             backend_port = 8000
         )
-        svc_web_at.initialize()
         svc_obj: Service = svc_web_at.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("web-at.json"))
         #print()
@@ -34,7 +33,6 @@ class ServiceWebTest(unittest.TestCase):
             backend_domain = "10.10.1.1",
             backend_port = 8080
         )
-        svc_web_conn.initialize()
         svc_obj = svc_web_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("web-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -52,7 +50,6 @@ class ServiceWebTest(unittest.TestCase):
             backend_tls = True,
             backend_tls_insecure = True
         )
-        svc_web_certs.initialize()
         svc_obj = svc_web_certs.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("web-certs.json"))
         assert_specs_equal(self, ref_obj, svc_obj)

--- a/tests/service_specs/test_web.py
+++ b/tests/service_specs/test_web.py
@@ -16,6 +16,7 @@ class ServiceWebTest(unittest.TestCase):
             backend_domain = "10.10.1.1",
             backend_port = 8000
         )
+        svc_web_at.initialize()
         svc_obj: Service = svc_web_at.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("web-at.json"))
         #print()
@@ -33,6 +34,7 @@ class ServiceWebTest(unittest.TestCase):
             backend_domain = "10.10.1.1",
             backend_port = 8080
         )
+        svc_web_conn.initialize()
         svc_obj = svc_web_conn.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("web-conn.json"))
         assert_specs_equal(self, ref_obj, svc_obj)
@@ -50,6 +52,7 @@ class ServiceWebTest(unittest.TestCase):
             backend_tls = True,
             backend_tls_insecure = True
         )
+        svc_web_certs.initialize()
         svc_obj = svc_web_certs.service_obj()
         ref_obj: Service = Service.Schema().loads(load_service_spec("web-certs.json"))
         assert_specs_equal(self, ref_obj, svc_obj)


### PR DESCRIPTION
1. deprecate the `service` command; instead use `service-web` or `service-infra` (we'll add `service-saas` and `service-tunnel` next)
2. add `quick-create-XXX` subcommands to create Web, SSH, K8S, RDP, DB, TCP services via specific params (instead of submitting the complete JSON service spec)
3. add tests